### PR TITLE
Repatch default params in manager.py

### DIFF
--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -40,6 +40,7 @@ def manager_init():
     ("IsRHD", "1"),
     ("OpenpilotEnabledToggle", "1"),
     ("RecordFront", "1"),
+    ("UploadRaw", "1"),
   ]
   if not PC:
     default_params.append(("LastUpdateTime", datetime.datetime.utcnow().isoformat().encode('utf8')))

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -33,9 +33,13 @@ def manager_init():
   params.clear_all(ParamKeyType.CLEAR_ON_MANAGER_START)
 
   default_params = [
+    ("CommunityFeaturesToggle", "1"),
     ("CompletedTrainingVersion", "0"),
     ("HasAcceptedTerms", "0"),
+    ("IsMetric", "1"),
+    ("IsRHD", "1"),
     ("OpenpilotEnabledToggle", "1"),
+    ("RecordFront", "1"),
   ]
   if not PC:
     default_params.append(("LastUpdateTime", datetime.datetime.utcnow().isoformat().encode('utf8')))


### PR DESCRIPTION
Repatch commit 7e00e93f2c8a5, modified for production use by not
setting the default values for terms, setup and training.