### PR TITLE
Add Remaining Upload in Software UI

### DIFF
--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -226,6 +226,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"Offroad_NvmeMissing", CLEAR_ON_MANAGER_START},
     {"ForcePowerDown", CLEAR_ON_MANAGER_START},
     {"JoystickDebugMode", CLEAR_ON_MANAGER_START | CLEAR_ON_IGNITION_OFF},
+    {"RemainingUploadSize",CLEAR_ON_MANAGER_START},
 };
 
 } // namespace

--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -262,6 +262,7 @@ def uploader_fn(exit_event):
     allow_raw_upload = params.get_bool("UploadRaw")
 
     d = uploader.next_file_to_upload(with_raw=allow_raw_upload and on_wifi and offroad)
+    params.put("RemainingUploadSize",str(int((uploader.immediate_size + uploader.raw_size)/1000000)) + " MB")
     if d is None:  # Nothing to upload
       if allow_sleep:
         time.sleep(60 if offroad else 5)

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -77,6 +77,7 @@ def manager_init():
   params.put("GitCommit", get_git_commit(default=""))
   params.put("GitBranch", get_git_branch(default=""))
   params.put("GitRemote", get_git_remote(default=""))
+  params.put("RemainingUploadSize","Loading...") # Provide an initial value incase uploader fails
 
   # set dongle id
   reg_res = register(show_spinner=True)

--- a/selfdrive/ui/qt/home.cc
+++ b/selfdrive/ui/qt/home.cc
@@ -176,7 +176,9 @@ void OffroadHome::refresh() {
 
   // pop-up new notification
   int idx = center_layout->currentIndex();
-  if (!updateAvailable && !alerts) {
+  // Kommu Edits:
+  //if (!updateAvailable && !alerts) {
+  if (!updateAvailable){
     idx = 0;
   } else if (updateAvailable && (!update_notif->isVisible() || (!alerts && idx == 2))) {
     idx = 1;

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -30,7 +30,7 @@ TogglesPanel::TogglesPanel(QWidget *parent) : QWidget(parent) {
   QList<ParamControl*> toggles;
 
   toggles.append(new ParamControl("OpenpilotEnabledToggle",
-                                  "Enable openpilot",
+                                  "Enable bukapilot",
                                   "Use the openpilot system for adaptive cruise control and lane keep driver assistance. Your attention is required at all times to use this feature. Changing this setting takes effect when the car is powered off.",
                                   "../assets/offroad/icon_openpilot.png",
                                   this));
@@ -206,6 +206,8 @@ SoftwarePanel::SoftwarePanel(QWidget* parent) : QWidget(parent) {
   osVersionLbl = new LabelControl("OS Version");
   versionLbl = new LabelControl("Version", "", QString::fromStdString(params.get("ReleaseNotes")).trimmed());
   lastUpdateLbl = new LabelControl("Last Update Check", "", "The last time openpilot successfully checked for an update. The updater only runs while the car is off.");
+  remainingUploadsLbl = new LabelControl("Remaining Uploads");
+
   updateBtn = new ButtonControl("Check for Update", "");
   connect(updateBtn, &ButtonControl::released, [=]() {
     if (params.getBool("IsOffroad")) {
@@ -219,7 +221,7 @@ SoftwarePanel::SoftwarePanel(QWidget* parent) : QWidget(parent) {
   });
 
   QVBoxLayout *main_layout = new QVBoxLayout(this);
-  QWidget *widgets[] = {versionLbl, lastUpdateLbl, updateBtn, gitBranchLbl, gitCommitLbl, osVersionLbl};
+  QWidget *widgets[] = {versionLbl, lastUpdateLbl, updateBtn, gitBranchLbl, gitCommitLbl, osVersionLbl, remainingUploadsLbl};
   for (int i = 0; i < std::size(widgets); ++i) {
     main_layout->addWidget(widgets[i]);
     if (i < std::size(widgets) - 1) {
@@ -260,6 +262,7 @@ void SoftwarePanel::updateLabels() {
   gitBranchLbl->setText(QString::fromStdString(params.get("GitBranch")));
   gitCommitLbl->setText(QString::fromStdString(params.get("GitCommit")).left(10));
   osVersionLbl->setText(QString::fromStdString(Hardware::get_os_version()).trimmed());
+  remainingUploadsLbl->setText(QString::fromStdString(params.get("RemainingUploadSize")));
 }
 
 QWidget * network_panel(QWidget * parent) {

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -42,6 +42,7 @@ private:
   LabelControl *osVersionLbl;
   LabelControl *versionLbl;
   LabelControl *lastUpdateLbl;
+  LabelControl *remainingUploadsLbl;
   ButtonControl *updateBtn;
 
   Params params;


### PR DESCRIPTION
- Changed Required NEOS Version
- Added RemainingUploadSize params
- Removed warning popup in homepage
- Add new row in Settings > Software tab showing remaining uploads
- Add default RemainingUploadSize params in manager.py