### PR TITLE
Revert "remove gpsd (#20027)"

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -32,7 +32,7 @@ STEER_ANGLE_SATURATION_THRESHOLD = 2.5  # Degrees
 
 SIMULATION = "SIMULATION" in os.environ
 NOSENSOR = "NOSENSOR" in os.environ
-IGNORE_PROCESSES = set(["rtshield", "uploader", "deleter", "loggerd", "logmessaged", "tombstoned", "logcatd", "proclogd", "clocksd", "updated", "timezoned", "manage_athenad"])
+IGNORE_PROCESSES = set(["rtshield", "uploader", "deleter", "loggerd", "logmessaged", "tombstoned", "logcatd", "proclogd", "clocksd", "gpsd", "updated", "timezoned", "manage_athenad"])
 
 ThermalStatus = log.DeviceState.ThermalStatus
 State = log.ControlsState.OpenpilotState

--- a/selfdrive/manager/process_config.py
+++ b/selfdrive/manager/process_config.py
@@ -11,6 +11,7 @@ procs = [
   NativeProcess("camerad", "selfdrive/camerad", ["./camerad"], unkillable=True, driverview=True),
   NativeProcess("clocksd", "selfdrive/clocksd", ["./clocksd"]),
   NativeProcess("dmonitoringmodeld", "selfdrive/modeld", ["./dmonitoringmodeld"], enabled=(not PC or WEBCAM), driverview=True),
+  NativeProcess("gpsd", "selfdrive/sensord", ["./gpsd"], enabled=EON, persistent=True),
   NativeProcess("logcatd", "selfdrive/logcatd", ["./logcatd"]),
   NativeProcess("loggerd", "selfdrive/loggerd", ["./loggerd"]),
   NativeProcess("modeld", "selfdrive/modeld", ["./modeld"]),

--- a/selfdrive/sensord/SConscript
+++ b/selfdrive/sensord/SConscript
@@ -1,7 +1,9 @@
 Import('env', 'arch', 'common', 'cereal', 'messaging')
-
 if arch == "aarch64":
   env.Program('_sensord', 'sensors_qcom.cc', LIBS=['hardware', common, cereal, messaging, 'capnp', 'zmq', 'kj'])
+  lenv = env.Clone()
+  lenv['LIBPATH'] += ['/system/vendor/lib64']
+  lenv.Program('_gpsd', ['gpsd.cc'], LIBS=['hardware', common, 'diag', 'time_genoff', cereal, messaging, 'capnp', 'zmq', 'kj'])
 else:
   sensors = [
     'sensors/file_sensor.cc',

--- a/selfdrive/sensord/gpsd
+++ b/selfdrive/sensord/gpsd
@@ -1,0 +1,3 @@
+#!/bin/sh
+export LD_LIBRARY_PATH="/system/lib64:$LD_LIBRARY_PATH"
+exec ./_gpsd

--- a/selfdrive/sensord/gpsd.cc
+++ b/selfdrive/sensord/gpsd.cc
@@ -1,0 +1,153 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+#include <sys/time.h>
+#include <sys/cdefs.h>
+#include <sys/types.h>
+#include <sys/resource.h>
+
+#include <pthread.h>
+
+#include <cutils/log.h>
+
+#include <hardware/gps.h>
+#include <utils/Timers.h>
+
+#include "cereal/messaging/messaging.h"
+#include "selfdrive/common/timing.h"
+#include "selfdrive/common/util.h"
+#include "selfdrive/common/swaglog.h"
+
+ExitHandler do_exit;
+
+namespace {
+
+PubMaster *pm;
+
+const GpsInterface* gGpsInterface = NULL;
+const AGpsInterface* gAGpsInterface = NULL;
+
+void nmea_callback(GpsUtcTime timestamp, const char* nmea, int length) {
+
+  uint64_t log_time_wall = nanos_since_epoch();
+
+  MessageBuilder msg;
+  auto nmeaData = msg.initEvent().initGpsNMEA();
+  nmeaData.setTimestamp(timestamp);
+  nmeaData.setLocalWallTime(log_time_wall);
+  nmeaData.setNmea(nmea);
+
+  pm->send("gpsNMEA", msg);
+}
+
+void location_callback(GpsLocation* location) {
+  MessageBuilder msg;
+  auto locationData = msg.initEvent().initGpsLocationExternal();
+  locationData.setFlags(location->flags);
+  locationData.setLatitude(location->latitude);
+  locationData.setLongitude(location->longitude);
+  locationData.setAltitude(location->altitude);
+  locationData.setSpeed(location->speed);
+  locationData.setBearingDeg(location->bearing);
+  locationData.setAccuracy(location->accuracy);
+  locationData.setTimestamp(location->timestamp);
+  locationData.setSource(cereal::GpsLocationData::SensorSource::ANDROID);
+
+  pm->send("gpsLocationExternal", msg);
+}
+
+pthread_t create_thread_callback(const char* name, void (*start)(void *), void* arg) {
+  LOG("creating thread: %s", name);
+  pthread_t thread;
+  pthread_attr_t attr;
+  int err;
+
+  err = pthread_attr_init(&attr);
+  err = pthread_create(&thread, &attr, (void*(*)(void*))start, arg);
+
+  return thread;
+}
+
+GpsCallbacks gps_callbacks = {
+  sizeof(GpsCallbacks),
+  location_callback,
+  NULL,
+  NULL,
+  nmea_callback,
+  NULL,
+  NULL,
+  NULL,
+  create_thread_callback,
+};
+
+void agps_status_cb(AGpsStatus *status) {
+  switch (status->status) {
+    case GPS_REQUEST_AGPS_DATA_CONN:
+      fprintf(stdout, "*** data_conn_open\n");
+      gAGpsInterface->data_conn_open("internet");
+      break;
+    case GPS_RELEASE_AGPS_DATA_CONN:
+      fprintf(stdout, "*** data_conn_closed\n");
+      gAGpsInterface->data_conn_closed();
+      break;
+  }
+}
+
+AGpsCallbacks agps_callbacks = {
+  agps_status_cb,
+  create_thread_callback,
+};
+
+void gps_init() {
+  pm = new PubMaster({"gpsNMEA", "gpsLocationExternal"});
+  LOG("*** init GPS");
+  hw_module_t* module = NULL;
+  hw_get_module(GPS_HARDWARE_MODULE_ID, (hw_module_t const**)&module);
+  assert(module);
+
+  static hw_device_t* device = NULL;
+  module->methods->open(module, GPS_HARDWARE_MODULE_ID, &device);
+  assert(device);
+
+  // ** get gps interface **
+  gps_device_t* gps_device = (gps_device_t *)device;
+  gGpsInterface = gps_device->get_gps_interface(gps_device);
+  assert(gGpsInterface);
+
+  gAGpsInterface = (const AGpsInterface*)gGpsInterface->get_extension(AGPS_INTERFACE);
+  assert(gAGpsInterface);
+
+
+  gGpsInterface->init(&gps_callbacks);
+  gAGpsInterface->init(&agps_callbacks);
+  gAGpsInterface->set_server(AGPS_TYPE_SUPL, "supl.google.com", 7276);
+
+  // gGpsInterface->delete_aiding_data(GPS_DELETE_ALL);
+  gGpsInterface->start();
+  gGpsInterface->set_position_mode(GPS_POSITION_MODE_MS_BASED,
+                                   GPS_POSITION_RECURRENCE_PERIODIC,
+                                   100, 0, 0);
+
+}
+
+void gps_destroy() {
+  delete pm;
+  gGpsInterface->stop();
+  gGpsInterface->cleanup();
+}
+
+}
+
+int main() {
+  setpriority(PRIO_PROCESS, 0, -13);
+
+  gps_init();
+
+  while(!do_exit) pause();
+
+  gps_destroy();
+
+  return 0;
+}

--- a/selfdrive/test/test_onroad.py
+++ b/selfdrive/test/test_onroad.py
@@ -37,6 +37,7 @@ PROCS = {
   "selfdrive.monitoring.dmonitoringd": 1.90,
   "./proclogd": 1.54,
   "selfdrive.logmessaged": 0.2,
+  "./_gpsd": 0.09,
   "./clocksd": 0.02,
   "./ubloxd": 0.02,
   "selfdrive.tombstoned": 0,


### PR DESCRIPTION
This reverts commit fe7f3f0ec6b66e42b26451e180e3cde241e749bb.
Manage `gpsd` as a NativeService on EON, publish ANDROID data to
gpsLocationExternal, distinguishable by `source` field.

Due to the likely extra if-branch when parsing GPS, consider publishing
it to another socket once the fallback/multisource logic is decided.