### PR TITLE
Add branch switching UI (crunched)

### DIFF
--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -1,6 +1,10 @@
 #include "selfdrive/ui/qt/offroad/settings.h"
 
 #include <cassert>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
 #include <string>
 
 #include <QDebug>
@@ -27,6 +31,65 @@
 #include "selfdrive/ui/qt/widgets/nav_buttons.h"
 #include "selfdrive/ui/ui.h"
 #include "selfdrive/ui/qt/util.h"
+
+BranchControl::BranchControl() : ButtonControl("Git Branch", "", "Warning: Only switch under advice from Kommu's staff.  Unauthorised switching will impose danger to you and other road users.") {
+  branch_label.setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+  branch_label.setStyleSheet("color: #aaaaaa");
+  hlayout->insertWidget(1, &branch_label);
+
+  QObject::connect(this, &ButtonControl::released, [=]() {
+    QString branch = InputDialog::getText("Enter branch name", this);
+    if (branch.length() > 0) {
+      switchToBranch(branch);
+    }
+  });
+
+  setText("SWITCH");
+  setEnabled(true);
+
+  refresh();
+}
+
+std::string BranchControl::readFile(const std::string filename) {
+  std::stringstream buf;
+  std::ifstream f(filename);
+  if (!f) {
+    return "_ERROR_";
+  }
+  buf << f.rdbuf();
+  return buf.str();
+}
+
+std::string BranchControl::getRealBranch() {
+  if (std::system("git rev-parse --abbrev-ref HEAD > _realbranch") == 0) {
+    return readFile("_realbranch");
+  }
+  return "_ERROR_";
+}
+
+void BranchControl::refresh() {
+  std::string label;
+  auto real = getRealBranch();
+  auto target = params.get("GitBranch");
+  if (real == "_ERROR_") {
+    label = real;
+    setEnabled(false);
+  } else {
+    if (target != real) {
+      label = target + " (pending)";
+    } else {
+      label = target;
+    }
+    setEnabled(true);
+  }
+  branch_label.setText(QString::fromStdString(label));
+}
+
+void BranchControl::switchToBranch(const QString &branch) {
+  params.put("GitBranch", branch.toStdString());
+  refresh();
+}
+
 
 TogglesPanel::TogglesPanel(QWidget *parent) : QWidget(parent) {
   QVBoxLayout *main_layout = new QVBoxLayout(this);
@@ -243,7 +306,7 @@ DevicePanel::DevicePanel(QWidget* parent) : QWidget(parent) {
 }
 
 SoftwarePanel::SoftwarePanel(QWidget* parent) : QWidget(parent) {
-  gitBranchLbl = new LabelControl("Git Branch");
+  branchControl = new BranchControl();
   gitCommitLbl = new LabelControl("Git Commit");
   osVersionLbl = new LabelControl("OS Version");
   versionLbl = new LabelControl("Version", "", QString::fromStdString(params.get("ReleaseNotes")).trimmed());
@@ -262,7 +325,7 @@ SoftwarePanel::SoftwarePanel(QWidget* parent) : QWidget(parent) {
   });
 
   QVBoxLayout *main_layout = new QVBoxLayout(this);
-  QWidget *widgets[] = {versionLbl, lastUpdateLbl, updateBtn, gitBranchLbl, gitCommitLbl, osVersionLbl};
+  QWidget *widgets[] = {versionLbl, lastUpdateLbl, updateBtn, branchControl, gitCommitLbl, osVersionLbl};
   for (int i = 0; i < std::size(widgets); ++i) {
     main_layout->addWidget(widgets[i]);
     if (i < std::size(widgets) - 1) {
@@ -294,11 +357,11 @@ void SoftwarePanel::updateLabels() {
     lastUpdate = timeAgo(QDateTime::fromString(QString::fromStdString(tm + "Z"), Qt::ISODate));
   }
 
+  branchControl->refresh();
   versionLbl->setText(getBrandVersion());
   lastUpdateLbl->setText(lastUpdate);
   updateBtn->setText("CHECK");
   updateBtn->setEnabled(true);
-  gitBranchLbl->setText(QString::fromStdString(params.get("GitBranch")));
   gitCommitLbl->setText(QString::fromStdString(params.get("GitCommit")).left(10));
   osVersionLbl->setText(QString::fromStdString(Hardware::get_os_version()).trimmed());
 }

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -11,6 +11,23 @@
 
 #include "selfdrive/ui/qt/widgets/controls.h"
 
+class BranchControl : public ButtonControl {
+  Q_OBJECT
+
+public:
+  BranchControl();
+
+  void refresh();
+
+private:
+  Params params;
+  QLabel branch_label;
+
+  std::string getRealBranch();
+  std::string readFile(const std::string filename);
+  void switchToBranch(const QString &branch);
+};
+
 // ********** settings window + top-level panels **********
 
 class DevicePanel : public QWidget {
@@ -36,7 +53,7 @@ private:
   void showEvent(QShowEvent *event) override;
   void updateLabels();
 
-  LabelControl *gitBranchLbl;
+  BranchControl *branchControl;
   LabelControl *gitCommitLbl;
   LabelControl *osVersionLbl;
   LabelControl *versionLbl;

--- a/selfdrive/updated.py
+++ b/selfdrive/updated.py
@@ -280,12 +280,20 @@ def check_git_fetch_result(fetch_txt):
   err_msg = "Failed to add the host to the list of known hosts (/data/data/com.termux/files/home/.ssh/known_hosts).\n"
   return len(fetch_txt) > 0 and (fetch_txt != err_msg)
 
+def check_for_branch_change():
+  setup_git_options(OVERLAY_MERGED)
+  try:
+    real_branch = run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    need_switch = real_branch != Params().get("GitBranch")
+    return need_switch
+  except subprocess.CalledProcessError:
+    return False
 
 def check_for_update() -> Tuple[bool, bool]:
   setup_git_options(OVERLAY_MERGED)
   try:
     git_fetch_output = run(["git", "fetch", "--dry-run"], OVERLAY_MERGED, low_priority=True)
-    return True, check_git_fetch_result(git_fetch_output)
+    return True, check_git_fetch_result(git_fetch_output) or check_for_branch_change()
   except subprocess.CalledProcessError:
     return False, False
 
@@ -294,6 +302,13 @@ def fetch_update(wait_helper: WaitTimeHelper) -> bool:
   cloudlog.info("attempting git fetch inside staging overlay")
 
   setup_git_options(OVERLAY_MERGED)
+
+  is_branch_change = check_for_branch_change()
+  switchto = Params().get("GitBranch", encoding="utf-8")
+
+  run(["git", "remote", "set-branches", "origin", f"{switchto}"], OVERLAY_MERGED, low_priority=True)
+  run(["git", "fetch", "origin"], OVERLAY_MERGED, low_priority=True)
+  run(["git", "checkout", "-B", switchto, "--track", f"origin/{switchto}"], OVERLAY_MERGED, low_priority=True)
 
   git_fetch_output = run(["git", "fetch"], OVERLAY_MERGED, low_priority=True)
   cloudlog.info("git fetch success: %s", git_fetch_output)
@@ -304,7 +319,7 @@ def fetch_update(wait_helper: WaitTimeHelper) -> bool:
   git_fetch_result = check_git_fetch_result(git_fetch_output)
 
   cloudlog.info("comparing %s to %s" % (cur_hash, upstream_hash))
-  if new_version or git_fetch_result:
+  if new_version or git_fetch_result or is_branch_change:
     cloudlog.info("Running update")
 
     if new_version:


### PR DESCRIPTION
Branch switching is done by updating GitBranch params, and will be
updated via `updated`.