### PR TITLE
Benfix20220519

### DIFF
--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -70,8 +70,12 @@ def manager_init():
   except PermissionError:
     print("WARNING: failed to make /dev/shm")
 
+  # get version
+  with open("/data/openpilot/RELEASES.md", "r") as f:
+    version = next(f).split()[1] # parse first line only
+
   # set version params
-  params.put("Version", params.get("ReleaseNotes").split()[1])
+  params.put("Version", version)
   params.put("TermsVersion", terms_version)
   params.put("TrainingVersion", training_version)
   params.put("GitCommit", get_git_commit(default=""))

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -50,37 +50,17 @@ BranchControl::BranchControl() : ButtonControl("Git Branch", "", "Warning: Only 
   refresh();
 }
 
-std::string BranchControl::readFile(const std::string filename) {
-  std::stringstream buf;
-  std::ifstream f(filename);
-  if (!f) {
-    return "_ERROR_";
-  }
-  buf << f.rdbuf();
-  return buf.str();
-}
-
-std::string BranchControl::getRealBranch() {
-  if (std::system("git rev-parse --abbrev-ref HEAD > _realbranch") == 0) {
-    return readFile("_realbranch");
-  }
-  return "_ERROR_";
-}
-
 void BranchControl::refresh() {
+  std::string real = exec("git rev-parse --abbrev-ref HEAD");
+  std::string target = params.get("GitBranch");
+  trim(real);
+  trim(target);
+
   std::string label;
-  auto real = getRealBranch();
-  auto target = params.get("GitBranch");
-  if (real == "_ERROR_") {
-    label = real;
-    setEnabled(false);
+  if (target != real) {
+    label = target + "(pending)";
   } else {
-    if (target != real) {
-      label = target + " (pending)";
-    } else {
-      label = target;
-    }
-    setEnabled(true);
+    label = target;
   }
   branch_label.setText(QString::fromStdString(label));
 }

--- a/selfdrive/ui/qt/offroad/settings.h
+++ b/selfdrive/ui/qt/offroad/settings.h
@@ -23,8 +23,6 @@ private:
   Params params;
   QLabel branch_label;
 
-  std::string getRealBranch();
-  std::string readFile(const std::string filename);
   void switchToBranch(const QString &branch);
 };
 

--- a/selfdrive/ui/qt/util.h
+++ b/selfdrive/ui/qt/util.h
@@ -42,3 +42,28 @@ signals:
 };
 
 std::string exec(const char* cmd);
+
+// https://stackoverflow.com/questions/216823/how-to-trim-a-stdstring
+#include <algorithm>
+#include <cctype>
+#include <locale>
+// trim from start (in place)
+static inline void ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }));
+}
+
+// trim from end (in place)
+static inline void rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }).base(), s.end());
+}
+
+// trim from both ends (in place)
+static inline void trim(std::string &s) {
+    ltrim(s);
+    rtrim(s);
+}
+


### PR DESCRIPTION
commit 040a2699485777d374a3c1d8aaa9d25e1e331124 (HEAD -> benfix20220519, origin/benfix20220519)
Author: Ben Masato <benmasato@kommu.ai>
Date:   Thu May 19 08:18:01 2022 +0000

    Fix version display fix in settings page

    The previous fix for version display uses FUTURE release note to
    determine the version, which is incorrect and will only be available
    when there is an update picked up by `updated`.

    This fix will fix the previous fix by reading the CURRENT release not to
    determine the version.

commit 21ff60a68101f98914b4e917c4fcaa1511f5db86
Author: Ben Masato <benmasato@kommu.ai>
Date:   Thu May 19 07:52:16 2022 +0000

    Fix branch name string comparison

    exec() and its friends return branch name with newline at the end,
    causing the string comparison to fail.  Add trim function to make sure
    newspace characters are trimmed before comparison.