### PR TITLE
Make runescapej use DongleId instead of RsjDongle

### DIFF
--- a/common/kommu.py
+++ b/common/kommu.py
@@ -47,7 +47,7 @@ def refresh_session():
 
   data = {
       "method": "password",
-      "password_identifier": params.get("RsjDongle"),
+      "password_identifier": params.get("DongleId"),
       "password": HARDWARE.get_imei(1) + HARDWARE.get_serial(),
   }
   resp = requests.post(init.json()["ui"]["action"], data=data)

--- a/selfdrive/athena/runescapej.py
+++ b/selfdrive/athena/runescapej.py
@@ -14,7 +14,6 @@ def register_user(imei, serial):
 
   # make sure the algo is the same with rsj!
   dongle_id = SHA224.new(data=(imei + serial).encode()).hexdigest()[:16]
-  params.put("RsjDongle", dongle_id)
 
   # first, try to login, WE MUST BE ABLE TO LOGIN IF DONGLE EXISTS
   # TODO: review threat model

--- a/selfdrive/common/params.cc
+++ b/selfdrive/common/params.cc
@@ -228,7 +228,6 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"ForcePowerDown", CLEAR_ON_MANAGER_START},
     {"JoystickDebugMode", CLEAR_ON_MANAGER_START | CLEAR_ON_IGNITION_OFF},
     {"MyviProfile", PERSISTENT},
-    {"RsjDongle", PERSISTENT},
     {"RsjSession", PERSISTENT},
 };
 

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -55,12 +55,6 @@ def manager_init():
     if params.get(k) is None:
       params.put(k, v)
 
-  # MIGRATE FROM KARAM
-  if params.get("RsjDongle") is None:
-    k = Karams()
-    params.put("RsjDongle", k.get("rsj_dongle"))
-    params.put("RsjSession", k.get("rsj_session"))
-
   # is this dashcam?
   if os.getenv("PASSIVE") is not None:
     params.put_bool("Passive", bool(int(os.getenv("PASSIVE"))))


### PR DESCRIPTION
Drop RsjDongle since DongleId and RsjDongle has the exact same value.
This also removes the need of a migrator from Karams.