### PR TITLE
Increased Proton SNG frequency (Testing)

### DIFF
--- a/selfdrive/car/proton/carcontroller.py
+++ b/selfdrive/car/proton/carcontroller.py
@@ -91,8 +91,8 @@ class CarController():
       #  fake_enable = False
       #can_sends.append(create_acc_cmd(self.packer, actuators.accel, fake_enable, (frame/2) % 16))
 
-    if CS.out.standstill and enabled and (frame % 50 == 0):
-      # Spam resume button to resume from standstill at max freq of 10 Hz.
+    if CS.out.standstill and enabled and (frame % 29 == 0):
+      # Spam resume button to resume from standstill at max freq of 34.48 Hz.
       if not self.mads or CS.acc_req:
         can_sends.append(send_buttons(self.packer, frame % 16, False))
 


### PR DESCRIPTION
Proton SNG frequency of 41.67 Hz (24 frames), 40 Hz (25 frames) and 38.46 Hz (26 frames) would increase the set speed by itself.

33.33 Hz (30 frames) and 32.26 Hz (31 frames) failed to start in SNG traffic but still increased the set speed by itself.

34.48 Hz (29 frames) never fails but it would still also increase the set speed, it seems to be the optimal value that doesn't fail to start and doesn't increase the set speed as often as other values.

I have noticed when SNG is set to 32.26 Hz (31 frames), it is more likely to increase the set speed compared to 34.48 Hz (29 frames).