### PR TITLE
Proton LKS off will now disable bukapilot LKA

### DIFF
--- a/opendbc/proton_general_pt.dbc
+++ b/opendbc/proton_general_pt.dbc
@@ -186,11 +186,11 @@ BO_ 432 ADAS_LKAS: 8 XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
  SG_ LKAS_ENGAGED2 : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ LKAS_ENGAGED1 : 12|1@0+ (1,0) [0|1] "" XXX
+ SG_ LKS_ENABLE : 13|1@0+ (1,0) [0|1] "" XXX
  SG_ STOCK_LKS_SETTINGS : 23|8@0+ (1,0) [0|255] "" XXX
  SG_ SET_ME_1_1 : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ SET_ME_1_2 : 9|1@0+ (1,0) [0|1] "" XXX
  SG_ SET_ME_1_3 : 24|1@0+ (1,0) [0|1] "" XXX
- SG_ STARTUP : 13|1@0+ (1,0) [0|1] "" XXX
  SG_ STEER_CMD : 47|11@0+ (1,0) [0|15] "" XXX
  SG_ STEER_DIR : 52|1@0+ (1,0) [0|1] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX

--- a/selfdrive/car/proton/carcontroller.py
+++ b/selfdrive/car/proton/carcontroller.py
@@ -56,6 +56,7 @@ class CarController():
 
   def update(self, enabled, CS, frame, actuators, lead_visible, rlane_visible, llane_visible, pcm_cancel, ldw, laneActive):
     can_sends = []
+    laneActive = laneActive and not CS.out.lkaDisabled
     lat_active = enabled and laneActive
     # tester present - w/ no response (keeps radar disabled)
     if CS.CP.openpilotLongitudinalControl and self.disable_radar:

--- a/selfdrive/car/proton/carstate.py
+++ b/selfdrive/car/proton/carstate.py
@@ -40,6 +40,7 @@ class CarState(CarStateBase):
     self.stock_lks_settings2 = cp.vl["ADAS_LKAS"]["SET_ME_1_1"]
     self.steer_dir = cp.vl["ADAS_LKAS"]["STEER_DIR"]
     self.stock_ldp = bool(cp.vl["LKAS"]["LANE_DEPARTURE_WARNING_RIGHT"]) or bool(cp.vl["LKAS"]["LANE_DEPARTURE_WARNING_LEFT"])
+    ret.lkaDisabled = not bool(cp.vl["ADAS_LKAS"]["LKS_ENABLE"])
 
     ret.wheelSpeeds = self.get_wheel_speeds(
       cp.vl["WHEEL_SPEED"]['WHEELSPEED_F'],
@@ -195,6 +196,7 @@ class CarState(CarStateBase):
       ("LANE_DEPARTURE_WARNING_RIGHT", "LKAS", 1),
       ("LANE_DEPARTURE_WARNING_LEFT", "LKAS", 1),
       ("STOCK_FCW_TRIGGERED", "FCW", 1),
+      ("LKS_ENABLE", "ADAS_LKAS", 1)
     ]
     checks = []
 


### PR DESCRIPTION
The code was tested multiple times on Proton X50, now it works following the LKS settings of the car.