### PR TITLE
Hide "Stock Longitudinal Control" toggle

### DIFF
--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -140,8 +140,13 @@ def manager_init() -> None:
     params.put("FeaturesDict", json.dumps(new_dict))
     Features().set_package("default")
 
+  '''
   if Features().has("StockAcc"):
-    params.put("StockAccToggle_Allow", b'1')
+    params.put_bool("StockAccToggle_Allow", True)
+  else:
+    params.put_bool("StockAccToggle_Allow", False)
+  '''
+  params.put_bool("StockAccToggle_Allow", False)
 
   # set dongle id
   reg_res = register(show_spinner=True)


### PR DESCRIPTION
Added the else condition to hide toggle if the feature package is not used, the code is commented so it can be used again if needed in the future.

Currently hiding the toggle.