### PR TITLE
Update with unsaved changes only on tested branch

### DIFF
--- a/selfdrive/ui/qt/offroad/k_settings.cc
+++ b/selfdrive/ui/qt/offroad/k_settings.cc
@@ -303,7 +303,8 @@ SoftwarePanel::SoftwarePanel(QWidget* parent) : ListWidget(parent) {
       lastUpdateLbl->setText("Failed to fetch update");
       updateBtn->setText("CHECK");
       updateBtn->setEnabled(true);
-      if (params.get("UpdateStatus") == "noInternet") {updateLabels();}
+      std::string failedStatus = params.get("UpdateStatus");
+      if ((failedStatus == "noInternet") || (failedStatus == "unsavedChanges")) {updateLabels();}
     } else if (path.contains("LastUpdateTime") || path.contains("UpdateStatus")) {
       updateLabels();
     }
@@ -324,6 +325,9 @@ void SoftwarePanel::updateLabels() {
     lastUpdate = "Invalid date and time settings";
   } else if (not params.getBool("IsOffroad")) {
     lastUpdate = "Turn off the car to check for update";
+  } else if (status == "unsavedChanges") {
+    lastUpdate = "Changes unsaved, cannot update";
+    allowed = true;
   } else if (status == "success") {
     lastUpdate = "Successful, reboot to apply update";
     btnText = "REBOOT";


### PR DESCRIPTION
Fix the issue where when testing was being done with rebase, the changes which were being tested would be overwritten when the updater ran by itself.

The change still allows tested branches, e.g., release branch, to update with unsaved changes present.