### PR TITLE
UI and updater improvements

### DIFF
--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -300,7 +300,7 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
 
   EventName.startupNoFw: {
     ET.PERMANENT: StartupAlert("Car Unrecognized",
-                               "Check comma power connections",
+                               "Check Kommu power connections",
                                alert_status=AlertStatus.userPrompt),
   },
 

--- a/selfdrive/loggerd/uploader.py
+++ b/selfdrive/loggerd/uploader.py
@@ -235,12 +235,16 @@ def uploader_fn(exit_event):
     offroad = params.get_bool("IsOffroad")
     network_type = sm['deviceState'].networkType if not force_wifi else NetworkType.wifi
     if network_type == NetworkType.none:
+      uploader.last_speed = 0
+      pm.send("uploaderState", uploader.get_msg())
       if allow_sleep:
         time.sleep(60 if offroad else 5)
       continue
 
     d = uploader.next_file_to_upload(network_type)
     if d is None:  # Nothing to upload
+      uploader.last_speed = 0
+      pm.send("uploaderState", uploader.get_msg())
       if allow_sleep:
         time.sleep(60 if offroad else 5)
       continue

--- a/selfdrive/ui/qt/k_home.cc
+++ b/selfdrive/ui/qt/k_home.cc
@@ -53,7 +53,7 @@ HomeWindow::HomeWindow(QWidget* parent) : QWidget(parent) {
 
 void HomeWindow::showEvent(QShowEvent *event) {
   refresh();
-  timer->start(10 * 1000);
+  timer->start(1 * 1000);
 }
 
 void HomeWindow::hideEvent(QHideEvent *event) {

--- a/selfdrive/ui/qt/offroad/k_settings.cc
+++ b/selfdrive/ui/qt/offroad/k_settings.cc
@@ -392,9 +392,21 @@ C2NetworkPanel::C2NetworkPanel(QWidget *parent) : ListWidget(parent) {
   // SSH key management
   addItem(new SshToggle());
   addItem(new SshControl());
+
+  timer = new QTimer(this);
+  timer->callOnTimeout(this, &C2NetworkPanel::updateLabels);
 }
 
 void C2NetworkPanel::showEvent(QShowEvent *event) {
+  updateLabels();
+  timer->start(1500);
+}
+
+void C2NetworkPanel::hideEvent(QHideEvent *event) {
+  timer->stop();
+}
+
+void C2NetworkPanel::updateLabels() {
   ipaddress->setText(getIPAddress());
   networkType->setText(getNetworkType());
 }

--- a/selfdrive/ui/qt/offroad/k_settings.cc
+++ b/selfdrive/ui/qt/offroad/k_settings.cc
@@ -286,8 +286,8 @@ SoftwarePanel::SoftwarePanel(QWidget* parent) : ListWidget(parent) {
       fs_watch->addPath(QString::fromStdString(params.getParamPath("LastUpdateTime")));
       fs_watch->addPath(QString::fromStdString(params.getParamPath("UpdateFailedCount")));
       fs_watch->addPath(QString::fromStdString(params.getParamPath("UpdateStatus")));
-      updateBtn->setText("UPDATING");
-      updateBtn->setEnabled(false);
+      params.put("UpdateStatus", "checking");
+      updateLabels();
     }
     std::system("pkill -1 -f selfdrive.updated");
   });
@@ -299,20 +299,20 @@ SoftwarePanel::SoftwarePanel(QWidget* parent) : ListWidget(parent) {
 
   fs_watch = new QFileSystemWatcher(this);
   QObject::connect(fs_watch, &QFileSystemWatcher::fileChanged, [=](const QString path) {
-    if (path.contains("UpdateFailedCount") && std::atoi(params.get("UpdateFailedCount").c_str()) > 0) {
-      lastUpdateLbl->setText("Failed to fetch update");
-      updateBtn->setText("CHECK");
-      updateBtn->setEnabled(true);
-      std::string failedStatus = params.get("UpdateStatus");
-      if ((failedStatus == "noInternet") || (failedStatus == "unsavedChanges")) {updateLabels();}
-    } else if (path.contains("LastUpdateTime") || path.contains("UpdateStatus")) {
-      updateLabels();
-    }
+    updateLabels();
   });
+
+  timer = new QTimer(this);
+  timer->callOnTimeout(this, &SoftwarePanel::updateLabels);
 }
 
 void SoftwarePanel::showEvent(QShowEvent *event) {
   updateLabels();
+  timer->start(1000);
+}
+
+void SoftwarePanel::hideEvent(QHideEvent *event) {
+  timer->stop();
 }
 
 void SoftwarePanel::updateLabels() {
@@ -334,16 +334,27 @@ void SoftwarePanel::updateLabels() {
     allowed = params.getBool("IsOffroad");
     connect(updateBtn, &ButtonControl::clicked, [=]() {
       updateBtn->setText("REBOOTING");
+      updateBtn->setEnabled(false);
       Params().putBool("DoReboot", true);
     });
-  } else if (status == "checking" || status == "prepareDownload"
-      || status == "downloading" || status == "installing") {
-    lastUpdate = "Updating";
+  } else if (status == "checking") {
+    btnText = "CHECKING";
+    lastUpdate = "Checking for update";
+  } else if (status == "prepareDownload") {
     btnText = "UPDATING";
-  } else if(!tm.empty()) {
+    lastUpdate = "Preparing to download update";
+  } else if (status == "downloading") {
+    btnText = "UPDATING";
+    lastUpdate = "Downloading update";
+  } else if (status == "installing") {
+    btnText = "UPDATING";
+    lastUpdate = "Installing update";
+  } else if (status == "fetchFailed") {
+    lastUpdate = "Failed to fetch update";
+    allowed = true;
+  } else if (!tm.empty()) {
     lastUpdate = "Checked " + timeAgo(QDateTime::fromString(QString::fromStdString(tm + "Z"), Qt::ISODate));
     allowed = true;
-    btnText = "CHECK";
     if (status == "noInternet") {
       lastUpdate += ", no internet";
     } else if (status == "latest") {

--- a/selfdrive/ui/qt/offroad/k_settings.h
+++ b/selfdrive/ui/qt/offroad/k_settings.h
@@ -243,9 +243,12 @@ public:
 
 private:
   void showEvent(QShowEvent *event) override;
+  void hideEvent(QHideEvent *event) override;
+  void updateLabels();
   QString getIPAddress();
   QString getNetworkType();
   LabelControl *ipaddress;
   LabelControl *networkType;
+  QTimer *timer;
 };
 

--- a/selfdrive/ui/qt/offroad/k_settings.h
+++ b/selfdrive/ui/qt/offroad/k_settings.h
@@ -219,6 +219,7 @@ public:
 
 private:
   void showEvent(QShowEvent *event) override;
+  void hideEvent(QHideEvent *event) override;
   void updateLabels();
 
   LabelControl *gitCommitLbl;
@@ -232,6 +233,7 @@ private:
 
   Params params;
   QFileSystemWatcher *fs_watch;
+  QTimer *timer;
 };
 
 class C2NetworkPanel: public ListWidget {

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -324,7 +324,11 @@ void Device::updateWakefulness(const UIState &s) {
   bool ignition_just_turned_off = !s.scene.ignition && ignition_on;
   ignition_on = s.scene.ignition;
 
-  if (ignition_just_turned_off || motionTriggered(s)) {
+  std::string updateStatus = Params().get("UpdateStatus");
+  bool updating = (updateStatus == "prepareDownload" || updateStatus == "downloading" ||
+                   updateStatus == "installing");
+
+  if (ignition_just_turned_off || motionTriggered(s) || updating) {
     resetInteractiveTimout();
   } else if (interactive_timeout > 0 && --interactive_timeout == 0) {
     emit interactiveTimout();


### PR DESCRIPTION
* Now the update UI can update automatically with the timer, code for the update UI and updater were improved and tested.

* A timer was added in C2NetworkPanel to keep updating the IP address and network type labels without having to close and open the panel.

* The refresh interval of the home screen was reduced from 10 seconds to 1 second, so that the drive data upload information is updated more often.

* The upload speed display would show the last speed instead of 0 when there's no internet connection or upload of files is finished, this was fixed.

* In ui.cc, a condition was added to keep the screen on during an update, but it keeps the screen on for any part of the UI during the update, not just the SoftwarePanel.