### PR TITLE
Revert "Keep display on if running an update"

### DIFF
--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -324,11 +324,7 @@ void Device::updateWakefulness(const UIState &s) {
   bool ignition_just_turned_off = !s.scene.ignition && ignition_on;
   ignition_on = s.scene.ignition;
 
-  std::string updateStatus = Params().get("UpdateStatus");
-  bool updating = (updateStatus == "prepareDownload" || updateStatus == "downloading" ||
-                   updateStatus == "installing");
-
-  if (ignition_just_turned_off || motionTriggered(s) || updating) {
+  if (ignition_just_turned_off || motionTriggered(s)) {
     resetInteractiveTimout();
   } else if (interactive_timeout > 0 && --interactive_timeout == 0) {
     emit interactiveTimout();


### PR DESCRIPTION
Reverting because during an update download, if internet is disconnected, or if an update is interrupted, it's possible the screen will not turn off.

This reverts commit a2e63bd1e9da6daffc945451fa114edf663b2fb9.