### PR TITLE
Proton and Assisted Lane Change and controlsd fixes

### DIFF
--- a/opendbc/proton_general_pt.dbc
+++ b/opendbc/proton_general_pt.dbc
@@ -202,12 +202,14 @@ BO_ 432 ADAS_LKAS: 8 XXX
  SG_ LKS_LDW : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ SET_ME_1_2 : 9|1@0+ (1,0) [0|1] "" XXX
  SG_ LKS_STATUS : 24|1@0+ (1,0) [0|1] "" XXX
- SG_ STEER_CMD : 47|11@0+ (1,0) [0|15] "" XXX
- SG_ STEER_DIR : 52|1@0+ (1,0) [0|1] "" XXX
  SG_ STOCK_LKS_AUX : 19|1@0+ (1,0) [0|1] "" XXX
  SG_ LKS_WARNING_AUDIO : 22|1@0+ (1,0) [0|1] "" XXX
  SG_ LKS_WARNING_TACTILE : 23|1@0+ (1,0) [0|1] "" XXX
  SG_ LKS_ENABLE_MAIN : 20|1@0+ (1,0) [0|1] "" XXX
+ SG_ STEER_CMD : 40|7@1+ (1,0) [0|74] "" XXX
+ SG_ STEER_DIR : 52|1@0+ (1,0) [0|1] "" XXX
+ SG_ LKAS_DIR_2 : 55|1@0+ (1,0) [0|1] "" XXX
+ SG_ LKAS_DIR_1 : 54|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 422 ADAS_LEAD_DETECT: 8 XXX
  SG_ LEAD_DISTANCE : 7|8@0+ (1,0) [0|255] "" XXX

--- a/selfdrive/car/proton/carcontroller.py
+++ b/selfdrive/car/proton/carcontroller.py
@@ -93,8 +93,8 @@ class CarController():
     # CAN controlled lateral running at 50hz
     if (frame % 2) == 0:
       can_sends.append(create_can_steer_command(self.packer, apply_steer, lat_active, \
-          CS.hand_on_wheel_warning and CS.is_icc_on, (frame/2) % 16, \
-          CS.lks_aux, CS.lks_audio, CS.lks_tactile, CS.lks_enable_main, CS.stock_ldw, enabled))
+      CS.hand_on_wheel_warning and CS.is_icc_on, CS.hand_on_wheel_warning_2 and CS.is_icc_on, \
+      (frame/2) % 16, CS.lks_aux, CS.lks_audio, CS.lks_tactile, CS.lks_enable_main, CS.stock_ldw, enabled))
 
       #can_sends.append(create_hud(self.packer, apply_steer, enabled, ldw, rlane_visible, llane_visible))
       #can_sends.append(create_lead_detect(self.packer, lead_visible, enabled))

--- a/selfdrive/car/proton/carcontroller.py
+++ b/selfdrive/car/proton/carcontroller.py
@@ -106,7 +106,7 @@ class CarController():
 
     # For resume
     if CS.out.standstill and enabled and self.resume_counter == 0 and \
-        frame > (self.last_res_press_frame + RES_INTERVAL) and CS.leadDistance > self.temp_lead_dist:
+        frame > (self.last_res_press_frame + RES_INTERVAL) and min(CS.leadDistance, 8) > self.temp_lead_dist:
       # Only start a new resume if the last one was finished, with an interval
       self.resume_counter = 1 # Start a new resume press
     elif not enabled or (enabled and not CS.out.standstill):

--- a/selfdrive/car/proton/carstate.py
+++ b/selfdrive/car/proton/carstate.py
@@ -20,6 +20,7 @@ class CarState(CarStateBase):
     self.is_cruise_latch = False
     self.acc_req = False
     self.hand_on_wheel_warning = False
+    self.hand_on_wheel_warning_2 = False
     self.is_icc_on = False
     self.prev_angle = 0
 
@@ -102,6 +103,7 @@ class CarState(CarStateBase):
     ret.steerWarning = False
     ret.steerError = False
     self.hand_on_wheel_warning = bool(cp.vl["ADAS_LKAS"]["HAND_ON_WHEEL_WARNING"])
+    self.hand_on_wheel_warning_2 = bool(cp.vl["ADAS_LKAS"]["WHEEL_WARNING_CHIME"])
     self.is_icc_on = bool(cp.vl["PCM_BUTTONS"]["ICC_ON"])
 
     ret.vEgoCluster = ret.vEgo * HUD_MULTIPLIER
@@ -196,6 +198,7 @@ class CarState(CarStateBase):
       ("CRUISE_ENABLE", "ACC_CMD", 1),
       ("ACC_REQ", "ACC_CMD", 1),
       ("HAND_ON_WHEEL_WARNING", "ADAS_LKAS", 1),
+      ("WHEEL_WARNING_CHIME", "ADAS_LKAS", 1),
       ("STOCK_LKS_AUX", "ADAS_LKAS", 0),
       ("LKS_WARNING_AUDIO", "ADAS_LKAS", 0),
       ("LKS_WARNING_TACTILE", "ADAS_LKAS", 0),

--- a/selfdrive/car/proton/carstate.py
+++ b/selfdrive/car/proton/carstate.py
@@ -99,7 +99,7 @@ class CarState(CarStateBase):
     self.prev_angle = ret.steeringAngleDeg
     ret.steeringTorque = cp.vl["STEERING_TORQUE"]['MAIN_TORQUE'] * steer_dir
     ret.steeringTorqueEps = cp.vl["STEERING_MODULE"]['STEER_RATE'] * steer_dir
-    ret.steeringPressed = bool(abs(ret.steeringTorqueEps) > 5)
+    ret.steeringPressed = bool(abs(ret.steeringTorque) > 30)
     ret.steerWarning = False
     ret.steerError = False
     self.hand_on_wheel_warning = bool(cp.vl["ADAS_LKAS"]["HAND_ON_WHEEL_WARNING"])

--- a/selfdrive/car/proton/carstate.py
+++ b/selfdrive/car/proton/carstate.py
@@ -9,8 +9,9 @@ from selfdrive.car.interfaces import CarStateBase
 from selfdrive.car.proton.values import DBC, CAR, HUD_MULTIPLIER
 from time import time
 from enum import Enum, auto
-
+from selfdrive.controls.lib.desire_helper import LANE_CHANGE_SPEED_MIN
 from common.features import Features
+from common.params import Params
 
 BLINKER_MIN = 3.5 # Minimum turn signal length in seconds
 
@@ -177,8 +178,11 @@ class CarState(CarStateBase):
         # Change in blinker direction
         set_cur_blinker()
 
-    ret.leftBlinker = self.cur_blinker == Dir.LEFT
-    ret.rightBlinker = self.cur_blinker == Dir.RIGHT
+    # Use minimum blinker time only if ALC is not active
+    alc_not_active = ret.vEgo < LANE_CHANGE_SPEED_MIN or not Params().get_bool("IsAlcEnabled")
+
+    ret.leftBlinker = (self.cur_blinker == Dir.LEFT) if alc_not_active else self.leftBlinker
+    ret.rightBlinker = (self.cur_blinker == Dir.RIGHT) if alc_not_active else self.rightBlinker
 
     # button presses
     ret.genericToggle = bool(cp.vl["LEFT_STALK"]["GENERIC_TOGGLE"]) # High beam toggle

--- a/selfdrive/car/proton/interface.py
+++ b/selfdrive/car/proton/interface.py
@@ -41,13 +41,13 @@ class CarInterface(CarInterfaceBase):
       ret.mass = 1370. + STD_CARGO_KG
       ret.wheelSpeedFactor = 1
 
-      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0.], [530]]
+      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0.], [74]]
 
       ret.lateralTuning.pid.kpBP = [0., 25., 35., 40.]
       ret.lateralTuning.pid.kpV = [0.05, 0.15, 0.15, 0.16]
       ret.lateralTuning.pid.kiBP = [0., 20., 30.]
-      ret.lateralTuning.pid.kiV = [0.10, 0.20, 0.40]
-      ret.lateralTuning.pid.kf = 0.00007
+      ret.lateralTuning.pid.kiV = [0.0400, 0.0800, 0.1600]
+      ret.lateralTuning.pid.kf = 0.000005
 
       ret.longitudinalTuning.kpBP = [0., 5., 20.]
       ret.longitudinalTuning.kpV = [0, 0, 0]
@@ -59,16 +59,16 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 15.00
       ret.centerToFront = ret.wheelbase * 0.44
       tire_stiffness_factor = 0.9871
-      ret.mass = 1300. + STD_CARGO_KG
+      ret.mass = 1312. + STD_CARGO_KG
       ret.wheelSpeedFactor = 1
 
-      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0.], [530]]
+      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0.], [74]]
 
       ret.lateralTuning.pid.kpBP = [0., 25., 35., 40.]
       ret.lateralTuning.pid.kpV = [0.05, 0.15, 0.15, 0.16]
       ret.lateralTuning.pid.kiBP = [0., 20., 30.]
-      ret.lateralTuning.pid.kiV = [0.10, 0.20, 0.40]
-      ret.lateralTuning.pid.kf = 0.00007
+      ret.lateralTuning.pid.kiV = [0.0400, 0.0800, 0.1600]
+      ret.lateralTuning.pid.kf = 0.000005
 
       ret.longitudinalTuning.kpBP = [0., 5., 20.]
       ret.longitudinalTuning.kpV = [0, 0, 0]
@@ -80,16 +80,37 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 15.00
       ret.centerToFront = ret.wheelbase * 0.44
       tire_stiffness_factor = 0.9871
-      ret.mass = 1705. + STD_CARGO_KG
+      ret.mass = 1740. + STD_CARGO_KG
       ret.wheelSpeedFactor = 1
 
-      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0.], [530]]
+      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0.], [74]]
 
       ret.lateralTuning.pid.kpBP = [0., 25., 35., 40.]
       ret.lateralTuning.pid.kpV = [0.05, 0.15, 0.15, 0.16]
       ret.lateralTuning.pid.kiBP = [0., 20., 30.]
-      ret.lateralTuning.pid.kiV = [0.10, 0.20, 0.40]
-      ret.lateralTuning.pid.kf = 0.00007
+      ret.lateralTuning.pid.kiV = [0.0400, 0.0800, 0.1600]
+      ret.lateralTuning.pid.kf = 0.000005
+
+      ret.longitudinalTuning.kpBP = [0., 5., 20.]
+      ret.longitudinalTuning.kpV = [0, 0, 0]
+      ret.longitudinalActuatorDelayLowerBound = 0.42
+      ret.longitudinalActuatorDelayUpperBound = 0.60
+
+    elif candidate == CAR.X70:
+      ret.wheelbase = 2.670
+      ret.steerRatio = 15.00
+      ret.centerToFront = ret.wheelbase * 0.44
+      tire_stiffness_factor = 0.9871
+      ret.mass = 1610. + STD_CARGO_KG
+      ret.wheelSpeedFactor = 1
+
+      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0.], [74]]
+
+      ret.lateralTuning.pid.kpBP = [0., 25., 35., 40.]
+      ret.lateralTuning.pid.kpV = [0.05, 0.15, 0.15, 0.16]
+      ret.lateralTuning.pid.kiBP = [0., 20., 30.]
+      ret.lateralTuning.pid.kiV = [0.0400, 0.0800, 0.1600]
+      ret.lateralTuning.pid.kf = 0.000005
 
       ret.longitudinalTuning.kpBP = [0., 5., 20.]
       ret.longitudinalTuning.kpV = [0, 0, 0]

--- a/selfdrive/car/proton/interface.py
+++ b/selfdrive/car/proton/interface.py
@@ -127,7 +127,7 @@ class CarInterface(CarInterfaceBase):
     # events
     events = self.create_common_events(ret)
 
-    if self.CS.hand_on_wheel_warning and self.CS.is_icc_on:
+    if (self.CS.hand_on_wheel_warning or self.CS.hand_on_wheel_warning_2) and self.CS.is_icc_on:
       events.add(EventName.protonHandOnWheelWarning)
 
     ret.events = events.to_msg()

--- a/selfdrive/car/proton/protoncan.py
+++ b/selfdrive/car/proton/protoncan.py
@@ -35,7 +35,7 @@ def compute_set_distance(state):
   else:
     return 0
 
-def create_can_steer_command(packer, steer, steer_req, wheel_touch_warning, raw_cnt,\
+def create_can_steer_command(packer, steer, steer_req, wheel_touch_warning, wheel_touch_warning_2, raw_cnt,\
     lks_aux, lks_audio, lks_tactile, lks_enable_main, stock_ldw, enabled):
   """Creates a CAN message for the Proton LKA Steer Command."""
   values = {
@@ -53,7 +53,7 @@ def create_can_steer_command(packer, steer, steer_req, wheel_touch_warning, raw_
     "LKS_WARNING_TACTILE": lks_tactile,
     "LKS_ENABLE_MAIN" : lks_enable_main,
     "HAND_ON_WHEEL_WARNING": wheel_touch_warning,
-    "WHEEL_WARNING_CHIME": 0,
+    "WHEEL_WARNING_CHIME": wheel_touch_warning_2,
   }
 
   dat = packer.make_can_msg("ADAS_LKAS", 0, values)[2]

--- a/selfdrive/car/proton/protoncan.py
+++ b/selfdrive/car/proton/protoncan.py
@@ -36,16 +36,16 @@ def compute_set_distance(state):
     return 0
 
 def create_can_steer_command(packer, steer, steer_req, wheel_touch_warning, raw_cnt,\
-    lks_aux, lks_audio, lks_tactile, lks_enable_main, stock_ldw):
+    lks_aux, lks_audio, lks_tactile, lks_enable_main, stock_ldw, enabled):
   """Creates a CAN message for the Proton LKA Steer Command."""
   values = {
     "LKAS_ENGAGED1": steer_req,
     "LKAS_LINE_ACTIVE": steer_req,
     "STEER_CMD": abs(steer) if steer_req else 0,
-    "STEER_DIR": 1 if steer <= 0 else 0,
+    "STEER_DIR": int(steer <= 0),
     "COUNTER": raw_cnt,
     # Disable steering vibration for LDW if LKS set to Warn Only mode and Tactile feedback type
-    "LKS_LDW": 0 if (not lks_aux and lks_tactile) else stock_ldw,
+    "LKS_LDW": 0 if (not lks_aux and lks_tactile and not enabled) else stock_ldw,
     "SET_ME_1_2": 1,
     "LKS_STATUS": 1,
     "STOCK_LKS_AUX": lks_aux,

--- a/selfdrive/car/proton/values.py
+++ b/selfdrive/car/proton/values.py
@@ -12,6 +12,7 @@ HUD_MULTIPLIER = 1.035
 class CAR:
   S70 = "PROTON S70"
   X50 = "PROTON X50"
+  X70 = "PROTON X70"
   X90 = "PROTON X90"
 
 FINGERPRINTS = {
@@ -23,6 +24,7 @@ FINGERPRINTS = {
 DBC = {
   CAR.S70: dbc_dict('proton_general_pt', None),
   CAR.X50: dbc_dict('proton_general_pt', None),
+  CAR.X70: dbc_dict('proton_general_pt', None),
   CAR.X90: dbc_dict('proton_general_pt', None),
 }
 

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -94,7 +94,7 @@ class CarState(CarStateBase):
     # we could use the override bit from dbc, but it's triggered at too high torque values
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD
     ret.steerWarning = cp.vl["EPS_STATUS"]["LKA_STATE"] not in (1, 5)
-    ret.lkaDisabled = not bool(cp.vl["LKAS_HUD"]["LKAS_STATUS"])
+    ret.lkaDisabled = False
 
     if self.CP.carFingerprint in (CAR.LEXUS_IS, CAR.LEXUS_RC):
       ret.cruiseState.available = cp.vl["DSU_CRUISE"]["MAIN_ON"] != 0

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -94,12 +94,14 @@ class Controls:
     if diff != blinker_diff:
       cooldown = 0 # Resume has no cooldown
 
+    angle_reduce = steeringAngle - CS.steeringAngleDeg
+
     if float(diff) < end_time:
       def out(ste):
         scaled_time = diff / (end_time - cooldown)
         mul = min(1, start_val + (1 - start_val) * (scaled_time ** (1-rate))) # Non-linear increment equation
         return ste * mul
-      return out(steer), out(steeringAngle)
+      return out(steer), (CS.steeringAngleDeg + out(angle_reduce))
     return steer, steeringAngle
 
   def __init__(self, sm=None, pm=None, can_sock=None):

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -289,19 +289,22 @@ class Controls:
         self.events.add(EventName.calibrationInvalid)
 
     # Handle lane change
-    if self.sm['lateralPlan'].laneChangeState == LaneChangeState.preLaneChange:
+    lc_state = self.sm['lateralPlan'].laneChangeState
+
+    if lc_state in (LaneChangeState.preLaneChange, LaneChangeState.laneChangeStarting, LaneChangeState.laneChangeFinishing):
       direction = self.sm['lateralPlan'].laneChangeDirection
-      if (CS.leftBlindspot and direction == LaneChangeDirection.left) or \
-         (CS.rightBlindspot and direction == LaneChangeDirection.right):
+      # Show blindspot event only for preLaneChange and Starting
+      if lc_state in (LaneChangeState.preLaneChange, LaneChangeState.laneChangeStarting) \
+          and ((CS.leftBlindspot and direction == LaneChangeDirection.left) or \
+          (CS.rightBlindspot and direction == LaneChangeDirection.right)):
         self.events.add(EventName.laneChangeBlocked)
-      else:
+      elif lc_state == LaneChangeState.preLaneChange:
         if direction == LaneChangeDirection.left:
           self.events.add(EventName.preLaneChangeLeft)
         else:
           self.events.add(EventName.preLaneChangeRight)
-    elif self.sm['lateralPlan'].laneChangeState in (LaneChangeState.laneChangeStarting,
-                                                    LaneChangeState.laneChangeFinishing):
-      self.events.add(EventName.laneChange)
+      else:
+        self.events.add(EventName.laneChange)
 
     if not CS.canValid:
       self.events.add(EventName.canError)

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -91,7 +91,7 @@ class Controls:
     diff = min(blinker_diff, resume_diff, lka_diff) # The last performed action
 
     if diff == blinker_diff and self.is_alc_active(CS):
-      diff = resume_diff # Only reduce steering for resume
+      diff = min(resume_diff, lka_diff) # Only reduce steering for resume and LKA resume
     if diff != blinker_diff:
       cooldown = 0 # Resume has no cooldown
 

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -89,10 +89,9 @@ class Controls:
     lka_diff = self.time_diff(self.last_lka_on_frame)
     diff = min(blinker_diff, resume_diff, lka_diff) # The last performed action
 
-    if diff == blinker_diff:
-      if self.is_alc_active():
-        diff = resume_diff # Only reduce steering for resume
-    if diff == resume_diff or diff == lka_diff:
+    if diff == blinker_diff and self.is_alc_active():
+      diff = resume_diff # Only reduce steering for resume
+    if diff != blinker_diff:
       cooldown = 0 # Resume has no cooldown
 
     if float(diff) < end_time:
@@ -582,11 +581,11 @@ class Controls:
         lac_log.saturated = abs(steer) >= 0.9
 
     # If steer resume
-    if not self.steer_resumed and lat_active:
+    if (not self.steer_resumed and lat_active) and (not CS.standstill):
       self.steer_resumed = True
       self.last_steer_resume_frame = self.sm.frame
     # If steer cancel
-    if self.steer_resumed and not lat_active:
+    if (self.steer_resumed and not lat_active) or CS.standstill:
       self.steer_resumed = False
 
     # If LKA switch on

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -81,8 +81,8 @@ class Controls:
   def reduce_steer(self, steer, steeringAngle):
     cooldown = LANE_CHANGE_COOLDOWN # Steering cooldown
     end_time = 1.75   # The time where the steering becomes 100% again
-    start_val = 0.075 # The percentage of steering when steering starts again
-    rate = 0.0015     # Higher value means steeper curve. When rate is 0, the curve becomes linear.
+    start_val = 0.00  # The percentage of steering when steering starts again
+    rate = 0.003      # Higher value means steeper curve. When rate is 0, the curve becomes linear.
 
     blinker_diff = self.time_diff(self.last_blinker_frame)
     resume_diff = self.time_diff(self.last_steer_resume_frame)

--- a/selfdrive/ui/ui.cc
+++ b/selfdrive/ui/ui.cc
@@ -290,8 +290,8 @@ void Device::updateBrightness(const UIState &s) {
       clipped_brightness = std::pow((clipped_brightness + 16.0) / 116.0, 3.0);
     }
 
-    // Scale back to 10% to 100%
-    clipped_brightness = std::clamp(100.0f * clipped_brightness, 10.0f, 100.0f);
+    // Scale back to 3% to 100%
+    clipped_brightness = std::clamp(100.0f * clipped_brightness, 3.0f, 100.0f);
   }
 
   int brightness = brightness_filter.update(clipped_brightness);


### PR DESCRIPTION
* 3b27828ab36507684a365658e22c1d506f7d40e1: [Hotfix] Revert Toyota lkaDisabled flag (from current `release` branch)
* 3bc97fc929af712c7560243efc4278ba3315aab0: Allow manual lane change when ALC is not active (the condition was changed again in a later commit: 326f89473d3efe84ded09ed6757e59a77f43e797), and added `( )` in line 668 so that if ALC is active, it's still possible to disable LKA.
* e5ff22c7bbf02419471632bc286a34db88c0ccd9: Fixed Proton LKS auxiliary code, but it only works the same way as the stock LKS after changing the `STEER_CMD` signal to 7 bits instead of 11 bits in the DBC file (c9cfeadb559cb248d6b9efc9faab09315003dbb3). For LKS warn only and tactile mode, disable stock steering LDW only when not enabled.
* 0fe8fd4fdc0f4489bd8b07eda3dcc438b8a8aed1: Allow 3% minimum screen brightness, since the original value 10% was still too bright at night.
* cc01b91ab66a4e1a186b6badbcde113de28cfb11: Pass the second Proton ICC steering warning to the car, and also add the event for it.
* 3a3704f8de77970035e9fcf6d27364ab5d06694e: Limit the Proton SNG auto resume distance, so that it won't suddenly accelerate without a lead car.
* c9cfeadb559cb248d6b9efc9faab09315003dbb3: DBC signal change for e5ff22c7bbf02419471632bc286a34db88c0ccd9, with new `kiv` value which makes sure that the steering control can be still overridden, and the new `kf` value which doesn't oversteer during a turn. The weights of Proton S70 Flagship, X90 Flagship, and X70 1.5 Premium X have been added.
* 9e1541ddb078aeff9ab6c1681c78733184181c19: Changing the steeringPressed value to the value of main torque, which is the actual steering driver torque. The new value has been tested to make sure the `steerSaturated` warning still appears when the car's limits are reached, while it won't appear for driver steering wheel overriding.
* da0bb1e6afea5a75ae1537b024228541acccd599: With this change, it's possible to cancel an Assisted Lane Change if turn signal is off or blindspot detected or turn signal direction change during `laneChangeStarting` state. The code in `controlsd` which shows the ALC events is also changed according to this change.
* d9a594d90d493fca3ae0a99be74e8677a4e62090: Adding a minimum turn signal duration (3.5 seconds) for Proton, for turn signal nudge.
* 10c46c153a6182679b66330bcd4a934426f48179: Starting the steering from 0% when resumed for smoothness and increased the rate of the curve.
* b127a187ae8e88e285fcec265a2450f98281c1f8: Simplified code in line 92 of `controlsd`, and added `CS.standstill` to make sure when car starts moving, steering is also reduced to be smooth, since bukapilot always disables steering control if the car is stopped.
*  fd1100707109baff4d74bf63c303f305f4375e9e: For angle based steering, reduce only the angle to be moved, not the target angle. (Needs to be tested on an angle based car)
* d7f3b04c37c3fba7e645ca8634946fb2a051c138: For Proton, if ALC is active, not use the minimum blinker duration.
* 326f89473d3efe84ded09ed6757e59a77f43e797: Add a delay if ALC is cancelled, so that for example if the driver accidentally moved the steering to another direction while cancelling ALC to avoid another car, it wouldn't start ALC to the other side. The ALC active condition is changed at here.
* a2191504fcb33f46d0fb1ef783b79e4fd098cce0: For Assisted Lane Change, only go to `preLaneChange` after turn signal is on for at least 0.2 seconds, so turn signal nudges can be ignored for ALC.
* 49d99b35d971e56c38b7c58918bba028935b692d: When ALC is active, also add steering reduction for smoother resume when LKA is enabled.