### PR TITLE
Remove duplicated X70 after automatic merge

### DIFF
--- a/selfdrive/car/proton/interface.py
+++ b/selfdrive/car/proton/interface.py
@@ -46,7 +46,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kpBP = [0., 25., 35., 40.]
       ret.lateralTuning.pid.kpV = [0.05, 0.15, 0.15, 0.16]
       ret.lateralTuning.pid.kiBP = [0., 20., 30.]
-      ret.lateralTuning.pid.kiV = [0.0400, 0.0800, 0.1600]
+      ret.lateralTuning.pid.kiV = [0.04, 0.08, 0.16]
       ret.lateralTuning.pid.kf = 0.000005
 
       ret.longitudinalTuning.kpBP = [0., 5., 20.]
@@ -67,7 +67,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kpBP = [0., 25., 35., 40.]
       ret.lateralTuning.pid.kpV = [0.05, 0.15, 0.15, 0.16]
       ret.lateralTuning.pid.kiBP = [0., 20., 30.]
-      ret.lateralTuning.pid.kiV = [0.0400, 0.0800, 0.1600]
+      ret.lateralTuning.pid.kiV = [0.04, 0.08, 0.16]
       ret.lateralTuning.pid.kf = 0.000005
 
       ret.longitudinalTuning.kpBP = [0., 5., 20.]
@@ -88,7 +88,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kpBP = [0., 25., 35., 40.]
       ret.lateralTuning.pid.kpV = [0.05, 0.15, 0.15, 0.16]
       ret.lateralTuning.pid.kiBP = [0., 20., 30.]
-      ret.lateralTuning.pid.kiV = [0.0400, 0.0800, 0.1600]
+      ret.lateralTuning.pid.kiV = [0.04, 0.08, 0.16]
       ret.lateralTuning.pid.kf = 0.000005
 
       ret.longitudinalTuning.kpBP = [0., 5., 20.]
@@ -109,29 +109,8 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kpBP = [0., 25., 35., 40.]
       ret.lateralTuning.pid.kpV = [0.05, 0.15, 0.15, 0.16]
       ret.lateralTuning.pid.kiBP = [0., 20., 30.]
-      ret.lateralTuning.pid.kiV = [0.0400, 0.0800, 0.1600]
+      ret.lateralTuning.pid.kiV = [0.04, 0.08, 0.16]
       ret.lateralTuning.pid.kf = 0.000005
-
-      ret.longitudinalTuning.kpBP = [0., 5., 20.]
-      ret.longitudinalTuning.kpV = [0, 0, 0]
-      ret.longitudinalActuatorDelayLowerBound = 0.42
-      ret.longitudinalActuatorDelayUpperBound = 0.60
-
-    elif candidate == CAR.X70:
-      ret.wheelbase = 2.670
-      ret.steerRatio = 15.00
-      ret.centerToFront = ret.wheelbase * 0.44
-      tire_stiffness_factor = 0.9871
-      ret.mass = 1675. + STD_CARGO_KG
-      ret.wheelSpeedFactor = 1
-
-      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0.], [530]]
-
-      ret.lateralTuning.pid.kpBP = [0., 25., 35., 40.]
-      ret.lateralTuning.pid.kpV = [0.05, 0.15, 0.15, 0.16]
-      ret.lateralTuning.pid.kiBP = [0., 20., 30.]
-      ret.lateralTuning.pid.kiV = [0.10, 0.20, 0.40]
-      ret.lateralTuning.pid.kf = 0.00007
 
       ret.longitudinalTuning.kpBP = [0., 5., 20.]
       ret.longitudinalTuning.kpV = [0, 0, 0]


### PR DESCRIPTION
Removed the duplicated X70 after the automatic merge of https://github.com/kommuai/bukapilot/pull/172
The one to be kept in the file is the one with the new tuning values and the weight of X70 2025.

The unnecessary `0`s in the `kiV` values are also removed.