### PR TITLE
ALC improvement for speed change and code simplification

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,17 @@
+Version 9.8.0  (2024-12-24)
+=========================
+* Allow Assisted Lane Change to be cancelled if turn signal is off, or blind spot detected during a lane change
+* Allow driver steering control when turn signal is on and below Assisted Lane Change speed
+* Smoother steering for stop and go traffic
+* Allow lower minimum screen brightness
+* Allow multiple features to be set in features package
+* Proton bukapilot lane keep follows LKS enable, to use bukapilot lane keep without stock LDW, set LKS to Warn Only and Tactile
+* Proton Lane Departure Prevention fix (LKS Auxiliary mode)
+* Proton one-touch turn signal of 3.5 seconds when Assisted Lane Change is not active
+* Improvements and new tuning for Proton port
+* UI improvements
+* Code optimisation
+
 Version 9.7.0  (2024-10-07)
 =========================
 * Smoother steering after resume/lane change with ALC off

--- a/selfdrive/car/proton/carcontroller.py
+++ b/selfdrive/car/proton/carcontroller.py
@@ -88,7 +88,6 @@ class CarController():
     self.steer_rate_limited = (new_steer != apply_steer) and (apply_steer != 0)
 
     ts = frame * DT_CTRL
-    self.is_alc_enabled = Params().get_bool("IsAlcEnabled")
 
     # CAN controlled lateral running at 50hz
     if (frame % 2) == 0:

--- a/selfdrive/car/proton/carstate.py
+++ b/selfdrive/car/proton/carstate.py
@@ -34,6 +34,7 @@ class CarState(CarStateBase):
 
     f = Features()
     self.mads = f.has("StockAcc")
+    self.is_alc_enabled = Params().get_bool("IsAlcEnabled")
 
     self.lks_aux = 0
     self.lks_audio = 0
@@ -179,7 +180,7 @@ class CarState(CarStateBase):
         set_cur_blinker()
 
     # Use minimum blinker time only if ALC is not active
-    alc_not_active = ret.vEgo < LANE_CHANGE_SPEED_MIN or not Params().get_bool("IsAlcEnabled")
+    alc_not_active = ret.vEgo < LANE_CHANGE_SPEED_MIN or not self.is_alc_enabled
 
     ret.leftBlinker = (self.cur_blinker == Dir.LEFT) if alc_not_active else self.leftBlinker
     ret.rightBlinker = (self.cur_blinker == Dir.RIGHT) if alc_not_active else self.rightBlinker

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -185,6 +185,7 @@ class Controls:
     elif self.CP.lateralTuning.which() == 'lqr':
       self.LaC = LatControlLQR(self.CP, self.CI)
 
+    self.laneActive = False
     self.initialized = False
     self.state = State.disabled
     self.enabled = False
@@ -574,7 +575,7 @@ class Controls:
       actuators.accel, actuators.speed = self.LoC.update(self.active, CS, self.CP, long_plan, pid_accel_limits)
 
       # Steering PID loop and lateral MPC
-      lat_active = self.active and not CS.steerWarning and not CS.steerError and CS.vEgo > self.CP.minSteerSpeed
+      lat_active = self.active and not CS.steerWarning and not CS.steerError and CS.vEgo > self.CP.minSteerSpeed and self.laneActive
       desired_curvature, desired_curvature_rate = get_lag_adjusted_curvature(self.CP, CS.vEgo,
                                                                              lat_plan.psis,
                                                                              lat_plan.curvatures,
@@ -684,6 +685,7 @@ class Controls:
     # 0.1s blinker cooldown after lane change, (for ALC not active) lane keep will be activated again after cooldown
     if (self.recent_blinker(LANE_CHANGE_COOLDOWN) and not self.is_alc_active(CS)) or CS.lkaDisabled:
       CC.laneActive = False
+    self.laneActive = CC.laneActive
 
     ldw_allowed = self.is_ldw_enabled and CS.vEgo > LDW_MIN_SPEED \
                     and not self.recent_blinker_2s() and not self.recent_steer_resume_2s() \

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -458,7 +458,7 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
   EventName.protonHandOnWheelWarning: {
     ET.WARNING: Alert(
       "Touch Steering Wheel",
-      "Set Proton ICC to ACC to remove warning",
+      "Set Proton ICC to ACC to Remove Warning",
       AlertStatus.userPrompt, AlertSize.mid,
       Priority.LOW, VisualAlert.none, AudibleAlert.none, .2),
   },


### PR DESCRIPTION
* 2cb5f5f8d1c5446b956b02a2501d846995a197ed: Capitalized Proton ICC warning event text.
* 9a607ae6c9583516bace062cb044a04b70e20501: Simplified `self.is_alc_enabled` so the parameter is not checked every time.
* a2fec902c296af09f58bc2f3b2cb125534f94523: With this change, if ALC is enabled, but blinker was on below ALC speed, ALC won't be active while blinker is still on when ALC speed is reached.
* cdf1190d3b3b828a8ea2cb179334f055ca1491b0: Adding `self.laneActive`, so that `lat_active` can follow self.laneActive, with this change, it's easier to determine if steering is disabled or enabled, without needing to check multiple times in the code.
* 8d2b2bdb4e26cbde60941dddad9ea2ad8d96b574: With the previous commit, since `self.laneAcrive` is used in `lat_active`, when `lat_active` is checked, it also includes the resume of LKA, so the additional code for checking LKA resume is not needed.
* 37a92d3beb9a82cb2a9b289e32f62e3c07d2b64f: Lance change cooldown is not needed and is removed, tested that the steering still feels smooth since now steering starts from 0%, the code was simplified. For LDW, only recent blinker on needs to be checked, while resume doesn't need to be checked because if steer is resumed, lane line will not be crossed if steering is being actively controlled.
* f5e88baf8d53ebf95727b417a37c74bd876b9362: If ALC was doing a lane change when speed changed to below 50 km/h, keep steering active, so that ALC can finish the lane change, the current code won't disable steering control until the driver has turned off the turn signal, so that steering won't be disabled without the driver noticing it.