### PR TITLE
Simplified `reduce_steer()` in controlsd, add event when ALC enabled but not active, Proton not use min blinker time if ALC active when blinker on.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,7 +1,7 @@
-Version 9.8.0  (2024-12-24)
+Version 9.8.0  (2024-12-26)
 =========================
+* **ALERT**: If Assisted Lane Change is enabled, below Assisted Lane Change speed, and turn signal is on, lane keep will be deactivated to allow manual steering control.
 * Allow Assisted Lane Change to be cancelled if turn signal is off, or blind spot detected during a lane change
-* Allow driver steering control when turn signal is on and below Assisted Lane Change speed
 * Smoother steering for stop and go traffic
 * Allow lower minimum screen brightness
 * Allow multiple features to be set in features package

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -126,7 +126,7 @@ class CarController():
     self.params = CarControllerParams(CP)
 
   def update(self, enabled, active, CS, frame, actuators, pcm_cancel_cmd,
-             hud_v_cruise, hud_show_lanes, hud_show_car, hud_alert):
+             hud_v_cruise, hud_show_lanes, hud_show_car, hud_alert, laneActive):
 
     P = self.params
 
@@ -186,7 +186,7 @@ class CarController():
     # Send steering command.
     idx = frame % 4
     can_sends.append(hondacan.create_steering_control(self.packer, apply_steer,
-      lkas_active, CS.CP.carFingerprint, idx, CS.CP.openpilotLongitudinalControl))
+      lkas_active and laneActive, CS.CP.carFingerprint, idx, CS.CP.openpilotLongitudinalControl))
 
     stopping = actuators.longControlState == LongCtrlState.stopping
 

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -433,7 +433,8 @@ class CarInterface(CarInterfaceBase):
                          hud_v_cruise,
                          hud_control.lanesVisible,
                          hud_show_car=hud_control.leadVisible,
-                         hud_alert=hud_control.visualAlert)
+                         hud_alert=hud_control.visualAlert,
+                         laneActive=c.laneActive)
 
     self.frame += 1
     return ret

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -47,7 +47,7 @@ class CarController():
     self.accel = 0
 
   def update(self, c, enabled, CS, frame, actuators, pcm_cancel_cmd, visual_alert, hud_speed,
-             left_lane, right_lane, left_lane_depart, right_lane_depart):
+             left_lane, right_lane, left_lane_depart, right_lane_depart, laneActive):
     # Steering Torque
     new_steer = int(round(actuators.steer * self.p.STEER_MAX))
     apply_steer = apply_std_steer_torque_limits(new_steer, self.apply_steer_last, CS.out.steeringTorque, self.p)
@@ -72,7 +72,7 @@ class CarController():
       if (frame % 100) == 0:
         can_sends.append([0x7D0, 0, b"\x02\x3E\x80\x00\x00\x00\x00\x00", 0])
 
-    can_sends.append(create_lkas11(self.packer, frame, self.car_fingerprint, apply_steer, lkas_active,
+    can_sends.append(create_lkas11(self.packer, frame, self.car_fingerprint, apply_steer, lkas_active and laneActive,
                                    CS.lkas11, sys_warning, sys_state, enabled,
                                    left_lane, right_lane,
                                    left_lane_warning, right_lane_warning))

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -376,6 +376,6 @@ class CarInterface(CarInterfaceBase):
     hud_control = c.hudControl
     ret = self.CC.update(c, c.enabled, self.CS, self.frame, c.actuators,
                          c.cruiseControl.cancel, hud_control.visualAlert, hud_control.setSpeed, hud_control.leftLaneVisible,
-                         hud_control.rightLaneVisible, hud_control.leftLaneDepart, hud_control.rightLaneDepart)
+                         hud_control.rightLaneVisible, hud_control.leftLaneDepart, hud_control.rightLaneDepart, c.laneActive)
     self.frame += 1
     return ret

--- a/selfdrive/car/proton/carcontroller.py
+++ b/selfdrive/car/proton/carcontroller.py
@@ -87,8 +87,6 @@ class CarController():
     apply_steer = apply_proton_steer_torque_limits(new_steer, self.last_steer, 0, self.params)
     self.steer_rate_limited = (new_steer != apply_steer) and (apply_steer != 0)
 
-    ts = frame * DT_CTRL
-
     # CAN controlled lateral running at 50hz
     if (frame % 2) == 0:
       can_sends.append(create_can_steer_command(self.packer, apply_steer, lat_active, \

--- a/selfdrive/car/proton/carcontroller.py
+++ b/selfdrive/car/proton/carcontroller.py
@@ -11,7 +11,7 @@ import cereal.messaging as messaging
 
 from common.features import Features
 
-RES_INTERVAL = 500
+RES_INTERVAL = 550
 RES_LEN = 2 # Press resume for 2 frames
 
 def apply_proton_steer_torque_limits(apply_torque, apply_torque_last, driver_torque, LIMITS):

--- a/selfdrive/car/proton/carstate.py
+++ b/selfdrive/car/proton/carstate.py
@@ -114,7 +114,7 @@ class CarState(CarStateBase):
     self.prev_angle = ret.steeringAngleDeg
     ret.steeringTorque = cp.vl["STEERING_TORQUE"]['MAIN_TORQUE'] * steer_dir
     ret.steeringTorqueEps = cp.vl["STEERING_MODULE"]['STEER_RATE'] * steer_dir
-    ret.steeringPressed = bool(abs(ret.steeringTorque) > 30)
+    ret.steeringPressed = bool(abs(ret.steeringTorque) > 31)
     ret.steerWarning = False
     ret.steerError = False
     self.hand_on_wheel_warning = bool(cp.vl["ADAS_LKAS"]["HAND_ON_WHEEL_WARNING"])

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -78,11 +78,9 @@ class Controls:
     angle_reduce = steeringAngle - CS.steeringAngleDeg
 
     if float(resume_diff) < end_time:
-      def out(ste):
-        scaled_time = resume_diff / end_time
-        mul = min(1, start_val + (1 - start_val) * (scaled_time ** (1-rate))) # Non-linear increment equation
-        return ste * mul
-      return out(steer), (CS.steeringAngleDeg + out(angle_reduce))
+      scaled_time = resume_diff / end_time
+      mul = min(1, start_val + (1 - start_val) * (scaled_time ** (1-rate))) # Non-linear increment equation
+      return (steer * mul), (CS.steeringAngleDeg + (angle_reduce * mul))
     return steer, steeringAngle
 
   def is_one_blinker(self, CS):

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -588,6 +588,9 @@ class Controls:
         lac_log.output = steer
         lac_log.saturated = abs(steer) >= 0.9
 
+    if self.is_alc_enabled and self.active and one_blinker and not (lat_active or CS.lkaDisabled or CS.standstill):
+      self.events.add(EventName.belowLaneChangeSpeed)
+
     # If steer resume
     if (not self.steer_resumed and lat_active) and (not CS.standstill):
       self.steer_resumed = True

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -70,18 +70,16 @@ class Controls:
     return self.time_diff(self.last_steer_resume_frame) < sec
 
   def reduce_steer(self, steer, steeringAngle, CS):
+    resume_diff = float(self.time_diff(self.last_steer_resume_frame))
     end_time = 1.75   # The time where the steering becomes 100% again
+    if resume_diff >= end_time:
+      return steer, steeringAngle
+
     start_val = 0.00  # The percentage of steering when steering starts again
     rate = 0.003      # Higher value means steeper curve. When rate is 0, the curve becomes linear.
-
-    resume_diff = self.time_diff(self.last_steer_resume_frame)
-    angle_reduce = steeringAngle - CS.steeringAngleDeg
-
-    if float(resume_diff) < end_time:
-      scaled_time = resume_diff / end_time
-      mul = min(1, start_val + (1 - start_val) * (scaled_time ** (1-rate))) # Non-linear increment equation
-      return (steer * mul), (CS.steeringAngleDeg + (angle_reduce * mul))
-    return steer, steeringAngle
+    # Non-linear increment equation
+    mul = min(1, start_val + (1 - start_val) * ((resume_diff / end_time) ** (1-rate)))
+    return steer * mul, (steeringAngle - CS.steeringAngleDeg) * mul + CS.steeringAngleDeg
 
   def is_one_blinker(self, CS):
     return CS.leftBlinker != CS.rightBlinker

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -642,7 +642,7 @@ class Controls:
     CC.enabled = self.enabled
     CC.active = self.active
     CC.actuators = actuators
-    CC.laneActive = self.laneActive = not (CS.lkaDisabled or (self.is_one_blinker(CS) and not self.is_alc_active(CS)))
+    CC.laneActive = self.laneActive = not (CS.lkaDisabled or CS.standstill or (self.is_one_blinker(CS) and not self.is_alc_active(CS)))
 
     orientation_value = self.sm['liveLocationKalman'].orientationNED.value
     if len(orientation_value) > 2:

--- a/selfdrive/controls/lib/desire_helper.py
+++ b/selfdrive/controls/lib/desire_helper.py
@@ -53,9 +53,8 @@ class DesireHelper:
     self.blinker_below_lane_change_speed = False
 
   def update(self, carstate, active, lane_change_prob):
-    v_ego = carstate.vEgo
     one_blinker = carstate.leftBlinker != carstate.rightBlinker
-    below_lane_change_speed = v_ego < LANE_CHANGE_SPEED_MIN
+    below_lane_change_speed = carstate.vEgo < LANE_CHANGE_SPEED_MIN
 
     blindspot_detected = ((carstate.leftBlindspot and self.lane_change_direction == LaneChangeDirection.left) or
                           (carstate.rightBlindspot and self.lane_change_direction == LaneChangeDirection.right))

--- a/selfdrive/controls/lib/events.py
+++ b/selfdrive/controls/lib/events.py
@@ -478,8 +478,8 @@ EVENTS: Dict[int, Dict[str, Union[Alert, AlertCallbackType]]] = {
 
   EventName.belowLaneChangeSpeed: {
     ET.WARNING: Alert(
-      "Below Auto Lane Change Speed",
-      "Manually Steer to Change Lane",
+      "Steer Manually",
+      "Turn Signal on Below Assisted Lane Change Speed",
       AlertStatus.userPrompt, AlertSize.mid,
       Priority.MID, VisualAlert.steerRequired, AudibleAlert.none, .1),
   },


### PR DESCRIPTION
The code was simplified to avoid calculating the value `mul` 2 times.