### PR TITLE
SNG auto resume fix, new X70 tuning values, and improved Proton carcontroller

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,11 +1,10 @@
-Version 9.8.2  (2025-02-03)
+Version 9.8.2  (2025-02-12)
 =========================
 * ALERT: ALL Proton models lane keep follows LKS/LKA enable, to use bukapilot lane keep without stock LDW, set LKS/LKA to Warn Only and Tactile.
 * ALERT: If Assisted Lane Change is enabled, below Assisted Lane Change speed, and turn signal is on, lane keep will be deactivated to allow manual steering control.
 * Improved edge case handling for Assisted Lane Change (WARNING: Driver attention is always required)
 * Proton X70 FL/S70 fix LKA settings and Centering Control LKA mode
 * Increased torque for Proton X50/S70
-* Display lead car triangle for Honda and Hyundai
 * Proton and BYD improved stop and go auto resume
 
 Version 9.8.0  (2024-12-26)

--- a/selfdrive/car/byd/carcontroller.py
+++ b/selfdrive/car/byd/carcontroller.py
@@ -4,8 +4,8 @@ from opendbc.can.packer import CANPacker
 from common.numpy_fast import clip
 
 RES_INTERVAL = 125
-SNG_WAIT = 350
-RES_LEN = 3
+SNG_WAIT = 310
+RES_LEN = 8
 
 def apply_byd_steer_angle_limits(apply_angle, actual_angle, v_ego, LIMITS):
   # pick angle rate limits based on wind up/down
@@ -55,24 +55,24 @@ class CarController():
 #      can_sends.append(create_accel_command(self.packer, actuators.accel, enabled, brake_hold, (frame/2) % 16))
       can_sends.append(create_lkas_hud(self.packer, enabled, CS.lss_state, CS.lss_alert, CS.tsr, CS.abh, CS.passthrough, CS.HMA, CS.pt2, CS.pt3, CS.pt4, CS.pt5, self.lka_active, frame % 16))
 
-    # For SNG auto resume
+    # SNG auto resume
     auto_resume_allowed = enabled and (CS.out.standstill or CS.out.cruiseState.standstill)
 
     if not auto_resume_allowed:
       self.is_sng_check = False
     else:
-      self.lead_valid &= lead_visible
+      self.lead_valid = self.lead_valid and lead_visible
 
       if not self.is_sng_check:
         # SNG auto resume check start
         self.is_sng_check = True
-        self.lead_valid = lead_visible
+        self.lead_valid = True
         self.sng_next_press_frame = frame + SNG_WAIT
         self.resume_counter = 0
 
       elif (CS.res_btn_pressed or CS.out.gasPressed) or self.resume_counter >= RES_LEN:
         # Manual press or auto resume finished
-        self.sng_next_press_frame = frame + RES_INTERVAL
+        self.sng_next_press_frame = max(self.sng_next_press_frame, frame + RES_INTERVAL)
         self.resume_counter = 0
 
       elif self.lead_valid and frame > self.sng_next_press_frame:

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -171,6 +171,10 @@ class CarController():
     can_sends = []
     if frame < 100:
       can_sends.append((2015, 0, b'\x01\x04\x00\x00\x00\x00\x00\x00', 1))
+    # tester present - w/ no response (keeps radar disabled)
+    if CS.CP.carFingerprint in HONDA_BOSCH and CS.CP.openpilotLongitudinalControl and False:
+      if (frame % 10) == 0:
+        can_sends.append((0x18DAB0F1, 0, b"\x02\x3E\x80\x00\x00\x00\x00\x00", 1))
 
     # for city low speed steer logic, active for awhile, disable for awhile.
     if CS.out.vEgo < 6:
@@ -182,7 +186,7 @@ class CarController():
     # Send steering command.
     idx = frame % 4
     can_sends.append(hondacan.create_steering_control(self.packer, apply_steer,
-      lkas_active, CS.CP.carFingerprint, idx, False))
+      lkas_active, CS.CP.carFingerprint, idx, CS.CP.openpilotLongitudinalControl))
 
     stopping = actuators.longControlState == LongCtrlState.stopping
 
@@ -216,7 +220,7 @@ class CarController():
       pcm_accel = int(clip((accel/1.44)/max_accel, 0.0, 1.0) * 0xc6)
 
     # Spoof for CRV
-    if True:
+    if not CS.CP.openpilotLongitudinalControl or True:
       if (frame % 2) == 0:
         idx = frame // 2
         # TODO Temporary remove to test if CRV intermittent fault still occurs
@@ -268,6 +272,12 @@ class CarController():
       idx = (frame//10) % 4
       #hud = HUDData(int(pcm_accel), int(round(hud_v_cruise)), hud_car, hud_lanes, fcw_display, acc_alert, steer_required)
       #can_sends.extend(hondacan.create_ui_commands(self.packer, CS.CP, pcm_speed, hud, CS.is_metric, idx, CS.stock_hud))
+
+      if (CS.CP.openpilotLongitudinalControl) and (CS.CP.carFingerprint not in HONDA_BOSCH):
+        self.speed = pcm_speed
+
+        if not CS.CP.enableGasInterceptor:
+          self.gas = pcm_accel / 0xc6
 
     new_actuators = actuators.copy()
     new_actuators.speed = self.speed

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -111,6 +111,9 @@ def get_can_signals(CP, gearbox_msg, main_on_sig_msg):
     signals.append(("DRIVERS_DOOR_OPEN", "SCM_FEEDBACK"))
   elif CP.carFingerprint == CAR.ODYSSEY_CHN:
     signals.append(("DRIVERS_DOOR_OPEN", "SCM_BUTTONS"))
+  elif CP.carFingerprint in (CAR.FREED, CAR.HRV):
+    signals += [("DRIVERS_DOOR_OPEN", "SCM_BUTTONS"),
+                ("WHEELS_MOVING", "STANDSTILL")]
   else:
     signals += [("DOOR_OPEN_FL", "DOORS_STATUS"),
                 ("DOOR_OPEN_FR", "DOORS_STATUS"),
@@ -188,6 +191,9 @@ class CarState(CarStateBase):
       ret.doorOpen = bool(cp.vl["SCM_FEEDBACK"]["DRIVERS_DOOR_OPEN"])
     elif self.CP.carFingerprint == CAR.ODYSSEY_CHN:
       ret.standstill = cp.vl["ENGINE_DATA"]["XMISSION_SPEED"] < 0.1
+      ret.doorOpen = bool(cp.vl["SCM_BUTTONS"]["DRIVERS_DOOR_OPEN"])
+    elif self.CP.carFingerprint in (CAR.FREED, CAR.HRV):
+      ret.standstill = not cp.vl["STANDSTILL"]["WHEELS_MOVING"]
       ret.doorOpen = bool(cp.vl["SCM_BUTTONS"]["DRIVERS_DOOR_OPEN"])
     else:
       ret.standstill = not cp.vl["STANDSTILL"]["WHEELS_MOVING"]

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -87,7 +87,7 @@ def get_can_signals(CP, gearbox_msg, main_on_sig_msg):
         ("EPB_STATUS", 0),
       ]
 
-    if True:
+    if not CP.openpilotLongitudinalControl:
       signals += [
         ("CRUISE_CONTROL_LABEL", "ACC_HUD"),
         ("CRUISE_SPEED", "ACC_HUD"),
@@ -138,6 +138,13 @@ def get_can_signals(CP, gearbox_msg, main_on_sig_msg):
     signals.append(("INTERCEPTOR_GAS", "GAS_SENSOR"))
     signals.append(("INTERCEPTOR_GAS2", "GAS_SENSOR"))
     checks.append(("GAS_SENSOR", 0))
+
+  if CP.openpilotLongitudinalControl:
+    signals += [
+      ("BRAKE_ERROR_1", "STANDSTILL"),
+      ("BRAKE_ERROR_2", "STANDSTILL")
+    ]
+    checks.append(("STANDSTILL", 0))
 
   return signals, checks
 
@@ -195,6 +202,8 @@ class CarState(CarStateBase):
     # LOW_SPEED_LOCKOUT is not worth a warning
     ret.steerWarning = steer_status not in ("NORMAL", "LOW_SPEED_LOCKOUT", "NO_TORQUE_ALERT_2")
 
+    if self.CP.openpilotLongitudinalControl:
+      self.brake_error = cp.vl["STANDSTILL"]["BRAKE_ERROR_1"] or cp.vl["STANDSTILL"]["BRAKE_ERROR_2"]
     ret.espDisabled = cp.vl["VSA_STATUS"]["ESP_DISABLED"] != 0
 
     ret.wheelSpeeds = self.get_wheel_speeds(
@@ -245,7 +254,7 @@ class CarState(CarStateBase):
       ret.steeringPressed |= abs(ret.steeringTorqueEps) > 4
       sign = -1 if ret.steeringRateDeg < 0 else 1
       ret.steeringTorque = ret.steeringTorqueEps * sign
-      if True:
+      if not self.CP.openpilotLongitudinalControl:
         ret.cruiseState.nonAdaptive = cp.vl["ACC_HUD"]["CRUISE_CONTROL_LABEL"] != 0
         ret.cruiseState.standstill = cp.vl["ACC_HUD"]["CRUISE_SPEED"] == 252.
 
@@ -290,7 +299,7 @@ class CarState(CarStateBase):
       self.is_metric = False
 
     if self.CP.carFingerprint in HONDA_BOSCH:
-      ret.stockAeb = bool(cp.vl["ACC_CONTROL"]["AEB_STATUS"] and cp.vl["ACC_CONTROL"]["ACCEL_COMMAND"] < -1e-5)
+      ret.stockAeb = (not self.CP.openpilotLongitudinalControl) and bool(cp.vl["ACC_CONTROL"]["AEB_STATUS"] and cp.vl["ACC_CONTROL"]["ACCEL_COMMAND"] < -1e-5)
     else:
       ret.stockAeb = bool(cp_cam.vl["BRAKE_COMMAND"]["AEB_REQ_1"] and cp_cam.vl["BRAKE_COMMAND"]["COMPUTER_BRAKE"] > 1e-5)
 

--- a/selfdrive/car/honda/hondacan.py
+++ b/selfdrive/car/honda/hondacan.py
@@ -101,8 +101,39 @@ def create_bosch_supplemental_1(packer, car_fingerprint, idx):
 def create_ui_commands(packer, CP, pcm_speed, hud, is_metric, idx, stock_hud):
   commands = []
   bus_pt = get_pt_bus(CP.carFingerprint)
-  radar_disabled = False
+  radar_disabled = CP.carFingerprint in HONDA_BOSCH and CP.openpilotLongitudinalControl
   bus_lkas = get_lkas_cmd_bus(CP.carFingerprint, radar_disabled)
+
+  if CP.openpilotLongitudinalControl:
+    if CP.carFingerprint in HONDA_BOSCH:
+      acc_hud_values = {
+        'CRUISE_SPEED': hud.v_cruise,
+        'ENABLE_MINI_CAR': 1,
+        'SET_TO_1': 1,
+        'HUD_LEAD': hud.car,
+        'HUD_DISTANCE': 3,
+        'ACC_ON': hud.car != 0,
+        'SET_TO_X1': 1,
+        'IMPERIAL_UNIT': int(not is_metric),
+        'FCM_OFF': 1,
+      }
+    else:
+      acc_hud_values = {
+        'PCM_SPEED': pcm_speed * CV.MS_TO_KPH,
+        'PCM_GAS': hud.pcm_accel,
+        'CRUISE_SPEED': hud.v_cruise,
+        'ENABLE_MINI_CAR': 1,
+        'HUD_LEAD': hud.car,
+        'HUD_DISTANCE': 3,    # max distance setting on display
+        'IMPERIAL_UNIT': int(not is_metric),
+        'SET_ME_X01_2': 1,
+        'SET_ME_X01': 1,
+        "FCM_OFF": stock_hud["FCM_OFF"],
+        "FCM_OFF_2": stock_hud["FCM_OFF_2"],
+        "FCM_PROBLEM": stock_hud["FCM_PROBLEM"],
+        "ICONS": stock_hud["ICONS"],
+      }
+    commands.append(packer.make_can_msg("ACC_HUD", bus_pt, acc_hud_values, idx))
 
   # Todo: Right now Honda City Malaysia can work by not blocking 0x33d (LKAS_HUD) but it faults once awhile.
   # If we do block it, it keeps faulting. For some reason, 0x33d has a constant value of b'\x00\x00\x80\x48\x00'
@@ -118,7 +149,7 @@ def create_ui_commands(packer, CP, pcm_speed, hud, is_metric, idx, stock_hud):
   if not (CP.flags & HondaFlags.BOSCH_EXT_HUD):
     lkas_hud_values['SET_ME_X48'] = 0x48
 
-  if CP.flags & HondaFlags.BOSCH_EXT_HUD:
+  if CP.flags & HondaFlags.BOSCH_EXT_HUD and not CP.openpilotLongitudinalControl:
     commands.append(packer.make_can_msg('LKAS_HUD_A', bus_lkas, lkas_hud_values, idx))
     commands.append(packer.make_can_msg('LKAS_HUD_B', bus_lkas, lkas_hud_values, idx))
   else:

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -31,15 +31,21 @@ class CarInterface(CarInterfaceBase):
   def get_params(candidate, fingerprint=gen_empty_fingerprint(), car_fw=[]):  # pylint: disable=dangerous-default-value
     ret = CarInterfaceBase.get_std_params(candidate, fingerprint)
     ret.carName = "honda"
-    ret.openpilotLongitudinalControl = True
 
     if candidate in HONDA_BOSCH:
       ret.safetyConfigs = [get_safety_config(car.CarParams.SafetyModel.hondaBosch)]
       ret.radarOffCan = True
-      ret.pcmCruise = True
+
+      # Disable the radar and let openpilot control longitudinal
+      # WARNING: THIS DISABLES AEB!
+      ret.openpilotLongitudinalControl = Params().get_bool("DisableRadar")
+
+      ret.pcmCruise = not ret.openpilotLongitudinalControl
     else:
       ret.safetyConfigs = [get_safety_config(car.CarParams.SafetyModel.hondaNidec)]
       ret.enableGasInterceptor = 0x201 in fingerprint[0]
+      ret.openpilotLongitudinalControl = True
+
       ret.pcmCruise = not ret.enableGasInterceptor
 
     if candidate == CAR.CRV_5G:
@@ -272,6 +278,9 @@ class CarInterface(CarInterfaceBase):
     if candidate in HONDA_NIDEC_ALT_SCM_MESSAGES:
       ret.safetyConfigs[0].safetyParam |= Panda.FLAG_HONDA_NIDEC_ALT
 
+    if ret.openpilotLongitudinalControl and candidate in HONDA_BOSCH:
+      ret.safetyConfigs[0].safetyParam |= Panda.FLAG_HONDA_BOSCH_LONG
+
     # min speed to enable ACC. if car can do stop and go, then set enabling speed
     # to a negative value, so it won't matter. Otherwise, add 0.5 mph margin to not
     # conflict with PCM acc
@@ -294,7 +303,8 @@ class CarInterface(CarInterfaceBase):
 
   @staticmethod
   def init(CP, logcan, sendcan):
-    pass
+    if CP.carFingerprint in HONDA_BOSCH and CP.openpilotLongitudinalControl:
+      disable_ecu(logcan, sendcan, bus=1, addr=0x18DAB0F1, com_cont_req=b'\x28\x83\x03')
 
   # returns a car.CarState
   def update(self, c, can_strings):
@@ -306,7 +316,7 @@ class CarInterface(CarInterfaceBase):
 
     ret = self.CS.update(self.cp, self.cp_cam, self.cp_body)
 
-    ret.canValid = True
+    ret.canValid = True or self.cp.can_valid and self.cp_cam.can_valid and (self.cp_body is None or self.cp_body.can_valid)
 
     buttonEvents = []
 
@@ -358,7 +368,7 @@ class CarInterface(CarInterfaceBase):
       # we engage when pcm is active (rising edge)
       if ret.cruiseState.enabled and not self.CS.out.cruiseState.enabled:
         events.add(EventName.pcmEnable)
-      elif not ret.cruiseState.enabled:
+      elif not ret.cruiseState.enabled and (c.actuators.accel >= 0. or not self.CP.openpilotLongitudinalControl):
         # it can happen that car cruise disables while comma system is enabled: need to
         # keep braking if needed or if the speed is very low
         if ret.vEgo < self.CP.minEnableSpeed + 2.:

--- a/selfdrive/car/honda/interface.py
+++ b/selfdrive/car/honda/interface.py
@@ -187,6 +187,28 @@ class CarInterface(CarInterfaceBase):
       tire_stiffness_factor = 0.75
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.05]]
 
+    elif candidate == CAR.FREED:
+      stop_and_go = False
+      ret.mass = 3086. * CV.LB_TO_KG + STD_CARGO_KG
+      ret.wheelbase = 2.74
+      # the remaining parameters were copied from FIT
+      ret.centerToFront = ret.wheelbase * 0.39
+      ret.steerRatio = 13.06
+      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]
+      tire_stiffness_factor = 0.75
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.05]]
+
+    elif candidate == CAR.HRV:
+      stop_and_go = False
+      ret.mass = 3125 * CV.LB_TO_KG + STD_CARGO_KG
+      ret.wheelbase = 2.61
+      ret.centerToFront = ret.wheelbase * 0.41
+      ret.steerRatio = 15.2
+      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]
+      tire_stiffness_factor = 0.5
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.16], [0.025]]
+      ret.wheelSpeedFactor = 1.025
+
     elif candidate == CAR.ACURA_RDX:
       stop_and_go = False
       ret.mass = 3935. * CV.LB_TO_KG + STD_CARGO_KG

--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -77,6 +77,8 @@ class CAR:
   CRV_EU = "HONDA CR-V EU 2016"
   CRV_HYBRID = "HONDA CR-V HYBRID 2019"
   FIT = "HONDA FIT 2018"
+  FREED = "HONDA FREED 2020"
+  HRV = "HONDA HRV 2019"
   ODYSSEY = "HONDA ODYSSEY 2018"
   ODYSSEY_CHN = "HONDA ODYSSEY CHN 2019"
   ACURA_RDX = "ACURA RDX 2018"
@@ -871,6 +873,29 @@ FW_VERSIONS = {
       b'77959-T5R-A230\x00\x00',
     ],
   },
+  CAR.FREED: {
+    (Ecu.gateway, 0x18daeff1, None): [
+      b'38897-TDK-J010\x00\x00',
+    ],
+    (Ecu.eps, 0x18da30f1, None): [
+      b'39990-TDK-J050\x00\x00',
+      b'39990-TDK-N020\x00\x00',
+    ],
+    # TODO: vsa is "essential" for fpv2 but doesn't appear on some models
+    (Ecu.vsa, 0x18da28f1, None): [
+      b'57114-TDK-J120\x00\x00',
+      b'57114-TDK-J330\x00\x00',
+    ],
+    (Ecu.combinationMeter, 0x18da60f1, None): [
+      b'78109-TDK-J310\x00\x00',
+      b'78109-TDK-J320\x00\x00',
+    ],
+    (Ecu.fwdRadar, 0x18dab0f1, None): [
+      b'36161-TDK-J070\x00\x00',
+      b'36161-TDK-J080\x00\x00',
+      b'36161-TDK-J530\x00\x00',
+    ],
+  },
   CAR.ODYSSEY: {
     (Ecu.gateway, 0x18daeff1, None): [
       b'38897-THR-A010\x00\x00',
@@ -1267,6 +1292,30 @@ FW_VERSIONS = {
       b'78109-TXM-A030\x00\x00',
     ],
   },
+  CAR.HRV: {
+    (Ecu.gateway, 0x18daeff1, None): [
+      b'38897-T7A-A010\x00\x00',
+      b'38897-T7A-A110\x00\x00',
+    ],
+    (Ecu.eps, 0x18da30f1, None): [
+      b'39990-THX-A020\x00\x00',
+    ],
+    (Ecu.fwdRadar, 0x18dab0f1, None): [
+      b'36161-T7A-A140\x00\x00',
+      b'36161-T7A-A240\x00\x00',
+      b'36161-T7A-C440\x00\x00',
+    ],
+    (Ecu.srs, 0x18da53f1, None): [
+      b'77959-T7A-A230\x00\x00',
+    ],
+    (Ecu.combinationMeter, 0x18da60f1, None): [
+      b'78109-THX-A110\x00\x00',
+      b'78109-THX-A120\x00\x00',
+      b'78109-THX-A210\x00\x00',
+      b'78109-THX-A220\x00\x00',
+      b'78109-THX-C220\x00\x00',
+    ],
+  },
   CAR.ACURA_ILX: {
     (Ecu.gateway, 0x18daeff1, None): [
       b'38897-TX6-A010\x00\x00',
@@ -1328,6 +1377,8 @@ DBC = {
   CAR.CRV_EU: dbc_dict('honda_crv_executive_2016_can_generated', 'acura_ilx_2016_nidec'),
   CAR.CRV_HYBRID: dbc_dict('honda_accord_2018_can_generated', None),
   CAR.FIT: dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),
+  CAR.FREED: dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),
+  CAR.HRV: dbc_dict('honda_fit_ex_2018_can_generated', 'acura_ilx_2016_nidec'),
   CAR.ODYSSEY: dbc_dict('honda_odyssey_exl_2018_generated', 'acura_ilx_2016_nidec'),
   CAR.ODYSSEY_CHN: dbc_dict('honda_odyssey_extreme_edition_2018_china_can_generated', 'acura_ilx_2016_nidec'),
   CAR.PILOT: dbc_dict('acura_ilx_2016_can_generated', 'acura_ilx_2016_nidec'),
@@ -1344,7 +1395,7 @@ STEER_THRESHOLD = {
 }
 
 HONDA_NIDEC_ALT_PCM_ACCEL = {CAR.ODYSSEY}
-HONDA_NIDEC_ALT_SCM_MESSAGES = {CAR.ACURA_ILX, CAR.ACURA_RDX, CAR.CRV, CAR.CRV_EU, CAR.FIT, CAR.ODYSSEY_CHN,
+HONDA_NIDEC_ALT_SCM_MESSAGES = {CAR.ACURA_ILX, CAR.ACURA_RDX, CAR.CRV, CAR.CRV_EU, CAR.FIT, CAR.FREED, CAR.HRV, CAR.ODYSSEY_CHN,
                                 CAR.PILOT, CAR.PASSPORT, CAR.RIDGELINE}
 HONDA_BOSCH = {CAR.ACCORD, CAR.ACCORDH, CAR.CIVIC_BOSCH, CAR.CIVIC_BOSCH_DIESEL, CAR.CRV_5G,
                CAR.CRV_HYBRID, CAR.INSIGHT, CAR.ACURA_RDX_3G, CAR.HONDA_E, CAR.CITY_BOSCH}

--- a/selfdrive/car/hyundai/carcontroller.py
+++ b/selfdrive/car/hyundai/carcontroller.py
@@ -67,7 +67,17 @@ class CarController():
 
     can_sends = []
 
-    if True:
+    # tester present - w/ no response (keeps radar disabled)
+    if CS.CP.openpilotLongitudinalControl:
+      if (frame % 100) == 0:
+        can_sends.append([0x7D0, 0, b"\x02\x3E\x80\x00\x00\x00\x00\x00", 0])
+
+    can_sends.append(create_lkas11(self.packer, frame, self.car_fingerprint, apply_steer, lkas_active,
+                                   CS.lkas11, sys_warning, sys_state, enabled,
+                                   left_lane, right_lane,
+                                   left_lane_warning, right_lane_warning))
+
+    if not CS.CP.openpilotLongitudinalControl:
       if pcm_cancel_cmd:
         can_sends.append(create_clu11(self.packer, frame, CS.clu11, Buttons.CANCEL))
       elif CS.out.cruiseState.standstill:
@@ -77,12 +87,36 @@ class CarController():
           can_sends.extend([create_clu11(self.packer, frame, CS.clu11, Buttons.RES_ACCEL)] * 25)
           self.last_resume_frame = frame
 
+    if frame % 2 == 0 and CS.CP.openpilotLongitudinalControl:
+      lead_visible = False
+      accel = actuators.accel if c.active else 0
+
+      jerk = clip(2.0 * (accel - CS.out.aEgo), -12.7, 12.7)
+
+      if accel < 0:
+        accel = interp(accel - CS.out.aEgo, [-1.0, -0.5], [2 * accel, accel])
+
+      accel = clip(accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX)
+
+      stopping = (actuators.longControlState == LongCtrlState.stopping)
+      set_speed_in_units = hud_speed * (CV.MS_TO_MPH if CS.clu11["CF_Clu_SPEED_UNIT"] == 1 else CV.MS_TO_KPH)
+      can_sends.extend(create_acc_commands(self.packer, enabled, accel, jerk, int(frame / 2), lead_visible, set_speed_in_units, stopping))
+      self.accel = accel
+
     # 20 Hz LFA MFA message
     if frame % 5 == 0 and self.car_fingerprint in (CAR.SONATA, CAR.PALISADE, CAR.IONIQ, CAR.KIA_NIRO_EV, CAR.KIA_NIRO_HEV_2021,
                                                    CAR.IONIQ_EV_2020, CAR.IONIQ_PHEV, CAR.KIA_CEED, CAR.KIA_SELTOS, CAR.KONA_EV,
                                                    CAR.ELANTRA_2021, CAR.ELANTRA_HEV_2021, CAR.SONATA_HYBRID, CAR.KONA_HEV, CAR.SANTA_FE_2022,
                                                    CAR.KIA_K5_2021, CAR.IONIQ_HEV_2022, CAR.SANTA_FE_HEV_2022, CAR.GENESIS_G70_2020, CAR.SANTA_FE_PHEV_2022):
       can_sends.append(create_lfahda_mfc(self.packer, enabled))
+
+    # 5 Hz ACC options
+    if frame % 20 == 0 and CS.CP.openpilotLongitudinalControl:
+      can_sends.extend(create_acc_opt(self.packer))
+
+    # 2 Hz front radar options
+    if frame % 50 == 0 and CS.CP.openpilotLongitudinalControl:
+      can_sends.append(create_frt_radar_opt(self.packer))
 
     new_actuators = actuators.copy()
     new_actuators.steer = apply_steer / self.p.STEER_MAX

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -52,6 +52,23 @@ class CarState(CarStateBase):
     ret.steeringPressed = abs(ret.steeringTorque) > STEER_THRESHOLD
     ret.steerWarning = cp.vl["MDPS12"]["CF_Mdps_ToiUnavail"] != 0 or cp.vl["MDPS12"]["CF_Mdps_ToiFlt"] != 0
 
+    # cruise state
+    if self.CP.openpilotLongitudinalControl:
+      # These are not used for engage/disengage since openpilot keeps track of state using the buttons
+      ret.cruiseState.available = cp.vl["TCS13"]["ACCEnable"] == 0
+      ret.cruiseState.enabled = cp.vl["TCS13"]["ACC_REQ"] == 1
+      ret.cruiseState.standstill = False
+    else:
+      ret.cruiseState.available = cp.vl["SCC11"]["MainMode_ACC"] == 1
+      ret.cruiseState.enabled = cp.vl["SCC12"]["ACCMode"] != 0
+      ret.cruiseState.standstill = cp.vl["SCC11"]["SCCInfoDisplay"] == 4.
+
+      if ret.cruiseState.enabled:
+        speed_conv = CV.MPH_TO_MS if cp.vl["CLU11"]["CF_Clu_SPEED_UNIT"] else CV.KPH_TO_MS
+        ret.cruiseState.speed = cp.vl["SCC11"]["VSetDis"] * speed_conv
+      else:
+        ret.cruiseState.speed = 0
+
     # TODO: Find brake pressure
     ret.brake = 0
     ret.brakePressed = cp.vl["TCS13"]["DriverBraking"] != 0
@@ -80,7 +97,7 @@ class CarState(CarStateBase):
 
     ret.gearShifter = self.parse_gear_shifter(self.shifter_values.get(gear))
 
-    if True:
+    if not self.CP.openpilotLongitudinalControl:
       if self.CP.carFingerprint in FEATURES["use_fca"]:
         ret.stockAeb = cp.vl["FCA11"]["FCA_CmdAct"] != 0
         ret.stockFcw = cp.vl["FCA11"]["CF_VSM_Warn"] == 2
@@ -173,7 +190,7 @@ class CarState(CarStateBase):
       ("SAS11", 0),
     ]
 
-    if True:
+    if not CP.openpilotLongitudinalControl:
       signals += [
         ("MainMode_ACC", "SCC11"),
         ("VSetDis", "SCC11"),

--- a/selfdrive/car/hyundai/interface.py
+++ b/selfdrive/car/hyundai/interface.py
@@ -25,9 +25,10 @@ class CarInterface(CarInterfaceBase):
     ret.safetyConfigs = [get_safety_config(car.CarParams.SafetyModel.hyundai, 0)]
     ret.radarOffCan = RADAR_START_ADDR not in fingerprint[1]
 
-    ret.openpilotLongitudinalControl = True
+    # WARNING: disabling radar also disables AEB (and we show the same warning on the instrument cluster as if you manually disabled AEB)
+    ret.openpilotLongitudinalControl = Params().get_bool("DisableRadar") and (candidate not in LEGACY_SAFETY_MODE_CAR)
 
-    ret.pcmCruise = True
+    ret.pcmCruise = not ret.openpilotLongitudinalControl
 
     ret.steerActuatorDelay = 0.1  # Default delay
     ret.steerRateCost = 0.5
@@ -274,11 +275,15 @@ class CarInterface(CarInterfaceBase):
 
     ret.enableBsm = 0x58b in fingerprint[0]
 
+    if ret.openpilotLongitudinalControl:
+      ret.safetyConfigs[0].safetyParam |= Panda.FLAG_HYUNDAI_LONG
+
     return ret
 
   @staticmethod
   def init(CP, logcan, sendcan):
-    pass
+    if CP.openpilotLongitudinalControl:
+      disable_ecu(logcan, sendcan, addr=0x7d0, com_cont_req=b'\x28\x83\x01')
 
   def update(self, c, can_strings):
     self.cp.update_strings(can_strings)
@@ -295,6 +300,37 @@ class CarInterface(CarInterfaceBase):
     if self.CS.park_brake:
       events.add(EventName.parkBrake)
 
+    if self.CS.CP.openpilotLongitudinalControl:
+      buttonEvents = []
+
+      if self.CS.cruise_buttons != self.CS.prev_cruise_buttons:
+        be = car.CarState.ButtonEvent.new_message()
+        be.type = ButtonType.unknown
+        if self.CS.cruise_buttons != 0:
+          be.pressed = True
+          but = self.CS.cruise_buttons
+        else:
+          be.pressed = False
+          but = self.CS.prev_cruise_buttons
+        if but == Buttons.RES_ACCEL:
+          be.type = ButtonType.accelCruise
+        elif but == Buttons.SET_DECEL:
+          be.type = ButtonType.decelCruise
+        elif but == Buttons.GAP_DIST:
+          be.type = ButtonType.gapAdjustCruise
+        elif but == Buttons.CANCEL:
+          be.type = ButtonType.cancel
+        buttonEvents.append(be)
+
+        ret.buttonEvents = buttonEvents
+
+        for b in ret.buttonEvents:
+          # do enable on both accel and decel buttons
+          if b.type in (ButtonType.accelCruise, ButtonType.decelCruise) and not b.pressed:
+            events.add(EventName.buttonEnable)
+          # do disable on button down
+          if b.type == ButtonType.cancel and b.pressed:
+            events.add(EventName.buttonCancel)
 
     # low speed steer alert hysteresis logic (only for cars with steer cut off above 10 m/s)
     self.operational_speed = False

--- a/selfdrive/car/proton/carcontroller.py
+++ b/selfdrive/car/proton/carcontroller.py
@@ -6,9 +6,9 @@ from common.params import Params
 from common.features import Features
 import time
 
-RES_INTERVAL = 600
-SNG_WAIT = 400
-RES_LEN = 2
+RES_INTERVAL = 500
+SNG_WAIT = 500
+RES_LEN = 8
 
 def apply_proton_steer_torque_limits(apply_torque, apply_torque_last, driver_torque, LIMITS):
 
@@ -55,7 +55,7 @@ class CarController():
     self.is_sng_check = False
     self.lead_valid = False
     self.prev_lead_dist = 0
-    self.send_res_press = False
+    self.lead_moved = True
 
     f = Features()
     self.mads = f.has("StockAcc")
@@ -109,33 +109,32 @@ class CarController():
       #  fake_enable = False
       #can_sends.append(create_acc_cmd(self.packer, actuators.accel, fake_enable, (frame/2) % 16))
 
-    # For SNG auto resume
+    # SNG auto resume
     auto_resume_allowed = enabled and CS.out.standstill
 
     if not auto_resume_allowed:
       self.is_sng_check = False
     else:
-      self.lead_valid &= CS.hasAnyLead
+      self.lead_valid = self.lead_valid and CS.hasAnyLead
       lead_dist = CS.leadDistance
-      self.send_res_press = self.lead_valid and \
-                            (self.send_res_press or (lead_dist > self.prev_lead_dist and frame > self.sng_next_press_frame))
+      self.lead_moved = self.lead_valid and (self.lead_moved or lead_dist > max(2, self.prev_lead_dist))
       self.prev_lead_dist = lead_dist
 
       if not self.is_sng_check:
         # SNG auto resume check start
         self.is_sng_check = True
+        self.lead_valid = True
         self.sng_next_press_frame = frame + SNG_WAIT
-        self.lead_valid = CS.hasAnyLead
         self.resume_counter = 0
-        self.send_res_press = False
+        self.lead_moved = False
 
       elif (CS.res_btn_pressed or CS.out.gasPressed) or self.resume_counter >= RES_LEN:
         # Manual press or auto resume finished
-        self.sng_next_press_frame = frame + RES_INTERVAL
+        self.sng_next_press_frame = max(self.sng_next_press_frame, frame + RES_INTERVAL)
         self.resume_counter = 0
-        self.send_res_press = False
+        self.lead_moved = False
 
-      elif self.send_res_press:
+      elif self.lead_moved and frame > self.sng_next_press_frame:
         # Send resume press signal
         if not self.mads or CS.acc_req:
           can_sends.append(send_buttons(self.packer, frame % 16, False))

--- a/selfdrive/car/proton/carcontroller.py
+++ b/selfdrive/car/proton/carcontroller.py
@@ -83,23 +83,25 @@ class CarController():
       self.last_steer_disable = time.monotonic()
     self.prev_steer_enabled = steer_enabled
 
-    stock_cmd = CS.stock_ldp_cmd
-    if not steer_enabled and stock_cmd > 0 and \
-        not ((CS.out.leftBlinker and CS.stock_ldp_left) or (CS.out.rightBlinker and CS.stock_ldp_right)):
+    stock_steer_cmd = CS.stock_ldp_cmd
+    if not steer_enabled and stock_steer_cmd > 0 and \
+       not ((CS.out.leftBlinker and CS.stock_ldp_left) or (CS.out.rightBlinker and CS.stock_ldp_right)):
       apply_stock_dir = -1 if CS.steer_dir else 1
 
-      # After disable, keep steering at 0 for the first 0.55 seconds, then increase from 0% to 100% over increase_duration.
+      # After steer disable, keep steering at 0 for the first 0.55 seconds, then increase from 0% to 100% over increase_duration.
       increase_duration = 0.5 # Duration in seconds for steering torque to increase from 0% to 100%
       disable_diff = time.monotonic() - self.last_steer_disable
       mul = max(0, min((disable_diff - 0.55) / increase_duration, 1))
-      apply_steer = int(round(stock_cmd * apply_stock_dir * mul)) &~1 # Ensure LSB 0 for 11-bit cmd
+      apply_steer = int(round(stock_steer_cmd * apply_stock_dir * mul)) &~1 # Ensure LSB 0 for 11-bit cmd
       lat_active, self.steer_rate_limited = True, False
 
     # CAN controlled lateral running at 50hz
-    if (frame % 2) == 0 and (CS.lks_audio is not None and CS.lks_tactile is not None): # Ensure LKS values are read
-      can_sends.append(create_can_steer_command(self.packer, apply_steer, lat_active, \
-      CS.hand_on_wheel_warning and CS.is_icc_on, CS.hand_on_wheel_warning_2 and CS.is_icc_on, \
-      (frame/2) % 16, CS.lks_aux, CS.lks_audio, CS.lks_tactile, CS.lks_assist_mode, CS.lka_enable, CS.stock_ldw, steer_enabled))
+    if frame % 2 == 0:
+      lks_audio, lks_tactile, is_icc_on = CS.lks_audio, CS.lks_tactile, CS.is_icc_on
+      if lks_audio is not None and lks_tactile is not None: # Ensure LKS values are read
+        can_sends.append(create_can_steer_command(self.packer, apply_steer, lat_active, \
+        CS.hand_on_wheel_warning and is_icc_on, CS.hand_on_wheel_warning_2 and is_icc_on, \
+        (frame//2) % 16, CS.lks_aux, lks_audio, lks_tactile, CS.lks_assist_mode, CS.lka_enable, CS.stock_ldw, steer_enabled))
 
       #can_sends.append(create_hud(self.packer, apply_steer, enabled, ldw, rlane_visible, llane_visible))
       #can_sends.append(create_lead_detect(self.packer, lead_visible, enabled))
@@ -107,7 +109,7 @@ class CarController():
       #  fake_enable = True
       #else:
       #  fake_enable = False
-      #can_sends.append(create_acc_cmd(self.packer, actuators.accel, fake_enable, (frame/2) % 16))
+      #can_sends.append(create_acc_cmd(self.packer, actuators.accel, fake_enable, (frame//2) % 16))
 
     # SNG auto resume
     auto_resume_allowed = enabled and CS.out.standstill

--- a/selfdrive/car/proton/interface.py
+++ b/selfdrive/car/proton/interface.py
@@ -103,15 +103,15 @@ class CarInterface(CarInterfaceBase):
       tire_stiffness_factor = 0.9871
       ret.mass = 1610. + STD_CARGO_KG
       ret.wheelSpeedFactor = 1
-      ret.steerActuatorDelay = 0.22
+      ret.steerActuatorDelay = 0.13
       ret.steerRateCost = 0.75
 
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0.], [500]]
 
       ret.lateralTuning.pid.kpBP = [0., 5., 15., 25., 35.]
-      ret.lateralTuning.pid.kpV = [0.001, 0.015, 0.045, 0.15, 0.17]
-      ret.lateralTuning.pid.kiBP = [0., 5., 15., 25.]
-      ret.lateralTuning.pid.kiV = [0.001, 0.01, 0.2, 0.5]
+      ret.lateralTuning.pid.kpV = [0.0005, 0.02, 0.06, 0.14, 0.17]
+      ret.lateralTuning.pid.kiBP = [0., 5., 15., 25., 35.]
+      ret.lateralTuning.pid.kiV = [0.001, 0.01, 0.09, 0.4, 0.5]
       ret.lateralTuning.pid.kf = 0.000006
 
       ret.longitudinalTuning.kpBP = [0., 5., 20.]

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -500,7 +500,8 @@ class Controls:
     # Assisted Lane Change and blinker checks
     below_lane_change_speed = CS.vEgo < LANE_CHANGE_SPEED_MIN
     lane_change_speed_enough = not below_lane_change_speed
-    one_blinker = CS.leftBlinker != CS.rightBlinker
+    leftBlinker, rightBlinker = CS.leftBlinker, CS.rightBlinker
+    one_blinker = leftBlinker != rightBlinker
 
     # Check if blinker was on below lane change speed for ALC
     if one_blinker:
@@ -529,11 +530,11 @@ class Controls:
 
     # Handle lane change events after ALC check
     if is_alc_active and (lc_state != LaneChangeState.off or lane_change_speed_enough) and not CS.lkaDisabled:
-      if one_blinker and ((CS.leftBlindspot and CS.leftBlinker) or (CS.rightBlindspot and CS.rightBlinker)):
+      if one_blinker and ((CS.leftBlindspot and leftBlinker) or (CS.rightBlindspot and rightBlinker)):
         self.events.add(EventName.laneChangeBlocked)
 
-      elif lc_state == LaneChangeState.preLaneChange:
-        if lat_plan.laneChangeDirection == LaneChangeDirection.left:
+      elif one_blinker and lc_state == LaneChangeState.preLaneChange:
+        if leftBlinker:
           self.events.add(EventName.preLaneChangeLeft)
         else:
           self.events.add(EventName.preLaneChangeRight)

--- a/selfdrive/controls/lib/desire_helper.py
+++ b/selfdrive/controls/lib/desire_helper.py
@@ -45,7 +45,7 @@ class DesireHelper:
     # https://github.com/kisapilot/openpilot/blob/93c8046/selfdrive/controls/lib/desire_helper.py
 
     # WARNING: No threshold can determine all road edges correctly. Driver check is still required.
-    edge_threshold = 0.47  # Higher value filters out low-confidence road edges
+    edge_threshold = 0.475  # Higher value filters out low-confidence road edges
     left_edge_prob = max(0.0, min(1.0 - md.roadEdgeStds[0], 1.0))
     right_edge_prob = max(0.0, min(1.0 - md.roadEdgeStds[1], 1.0))
     left_nearside_prob, right_nearside_prob = md.laneLineProbs[0], md.laneLineProbs[3]

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -198,7 +198,7 @@ void OnroadHud::updateState(const UIState &s) {
   setProperty("speed", QString::number(std::nearbyint(cur_speed)));
   setProperty("maxSpeed", maxspeed_str);
   setProperty("speedUnit", s.scene.is_metric ? "km/h" : "mph");
-  setProperty("temperature", QString::number(std::nearbyint(temp)) + (s.scene.is_metric ? "C" : "F"));
+  setProperty("temperature", QString::number(std::nearbyint(temp)) + (s.scene.is_metric ? "°C" : "°F"));
   setProperty("hideDM", cs.getAlertSize() != cereal::ControlsState::AlertSize::NONE);
   setProperty("status", s.status);
 


### PR DESCRIPTION
## Changes for SNG auto resume:
* Proton SNG ensure no early resume press if there is not enough distance.
* Ensure any manual button press will not overwrite the waiting period (first 3 seconds) after car is stopped.
* `self.lead_valid` default to `True` when SNG check is started for better performance, this change does not affect the result.
* Using `and` instead of `&=` to use Python short-circuiting for better performance.
* SNG interval and wait time adjustments for faster response, while making sure there is no unexpected speed increment.
* Increase resume press length to 8 frames (80ms) while previous 2 frames was enough to trigger a resume press, to be able to handle any frame drops while still providing faster response compared to the fastest human button press possible of 10 frames (100ms).

## Proton Stop and Go auto resume known limitations:

### Has a noticeable delay of up to 5.25 seconds if:
* The radar detects change of distance too late. (Stock system updates distance every 0.25 seconds)
* When the car is stopped by ACC, there is not enough distance, or the lead car suddenly stops while it was moving fast, causing the gap to be small.
* The driver stops the car manually and enables ACC, causing the gap to be too small and there is not enough distance.
* While the car is stopped and ACC is enabled, the driver presses the gas pedal to move the car forward.
* The driver presses the RES button or presses the gas pedal manually and the car didn't move.
* The lead car accelerates away too fast.
* The lead car stops for exactly 3 seconds, and suddenly accelerates away.

### Fails if:
* ACC error or failure due to rain.
* Human errors, if the driver forgets to enable ACC or the driver presses the brake pedal while not being aware of it, etc.
* Outside temperature is 35 °C or above. (Confirmed 100% fail, but no error or warning on car dashboard and KA device.)
* The lead car changes or moves away. (Lead could be a motorcycle or any moving objects/vehicles/pedestrians, etc.)
* The lead car is suddenly not detected.
* The lead car is not aligned with the car's ACC radar.
* Motorcycles and pedestrians go through the gap in front and run the red light, which triggers unexpected auto resume or makes auto resume fail.
* The lead car stops and suddenly accelerates away, and the change of distance isn't detected by the stock auto resume within 3 seconds.