### PR TITLE
Proton SNG use cruiseState with value adjustments

### DIFF
--- a/selfdrive/car/proton/carcontroller.py
+++ b/selfdrive/car/proton/carcontroller.py
@@ -6,8 +6,8 @@ from common.params import Params
 from common.features import Features
 import time
 
-RES_INTERVAL = 500
-SNG_WAIT = 500
+RES_INTERVAL = 150
+SNG_WAIT = RES_INTERVAL
 RES_LEN = 8
 
 def apply_proton_steer_torque_limits(apply_torque, apply_torque_last, driver_torque, LIMITS):
@@ -112,14 +112,14 @@ class CarController():
       #can_sends.append(create_acc_cmd(self.packer, actuators.accel, fake_enable, (frame//2) % 16))
 
     # SNG auto resume
-    auto_resume_allowed = enabled and CS.out.standstill
+    auto_resume_allowed = enabled and CS.out.cruiseState.standstill
 
     if not auto_resume_allowed:
       self.is_sng_check = False
     else:
-      self.lead_valid = self.lead_valid and CS.hasAnyLead
+      self.lead_valid = self.lead_valid and lead_visible
       lead_dist = CS.leadDistance
-      self.lead_moved = self.lead_valid and (self.lead_moved or lead_dist > max(2, self.prev_lead_dist))
+      self.lead_moved = self.lead_valid and (self.lead_moved or lead_dist > max(1, self.prev_lead_dist))
       self.prev_lead_dist = lead_dist
 
       if not self.is_sng_check:

--- a/selfdrive/car/proton/carstate.py
+++ b/selfdrive/car/proton/carstate.py
@@ -121,7 +121,6 @@ class CarState(CarStateBase):
     self.hand_on_wheel_warning = bool(cp.vl["ADAS_LKAS"]["HAND_ON_WHEEL_WARNING"])
     self.hand_on_wheel_warning_2 = bool(cp.vl["ADAS_LKAS"]["WHEEL_WARNING_CHIME"])
     self.leadDistance = cp.vl["ADAS_LEAD_DETECT"]["LEAD_DISTANCE"]
-    self.hasAnyLead = bool(cp.vl["ADAS_LEAD_DETECT"]["IS_LEAD2"])
     self.is_icc_on = bool(cp.vl["PCM_BUTTONS"]["ICC_ON"])
     self.lka_enable = bool(cp.vl["ADAS_LKAS"]["LKA_ENABLE"])
     # If cruise mode is ICC, make bukapilot control steering so it won't disengage.
@@ -221,7 +220,6 @@ class CarState(CarStateBase):
       # sig_name, sig_address, default
       ("RES_BUTTON", "ACC_BUTTONS", 0),
       ("LEAD_DISTANCE", "ADAS_LEAD_DETECT", 0.),
-      ("IS_LEAD2", "ADAS_LEAD_DETECT", 0),
       ("WHEELSPEED_F", "WHEEL_SPEED", 0.),
       ("WHEELSPEED_B", "WHEEL_SPEED", 0.),
       ("SET_DISTANCE", "PCM_BUTTONS", 0.),


### PR DESCRIPTION
Use cruiseState standstill (car signal instead of raw speed) for less delay, and prevent unexpected speed increments. Use AI lead detection instead of stock lead detection since stock detection can fail easily (when motorcycles and pedestrians go through) .

The SNG_WAIT value after testing, still cannot confirm if it should be RES_INTERVAL or 300 (3 seconds) + RES_INTERVAL, but current value of RES_INTERVAL as SNG_WAIT was tested working in most cases without issues, and still works for stop and suddenly go traffic.

There is still a possibility for auto resume to increase the speed if the car is going slightly uphill. And auto resume still causes rollback if the road is too steep, this is the car gearbox limitation.

It is known that the code will not make the car resume immediately if ACC is only enabled by the driver after lead car starts moving. When enabled, the front car has to be stationary or both cars have to be already moving.