### PR TITLE
Code optimisation for controlsd and Proton interface

### DIFF
--- a/selfdrive/car/proton/carcontroller.py
+++ b/selfdrive/car/proton/carcontroller.py
@@ -106,7 +106,7 @@ class CarController():
 
       #can_sends.append(create_hud(self.packer, apply_steer, enabled, ldw, rlane_visible, llane_visible))
       #can_sends.append(create_lead_detect(self.packer, lead_visible, enabled))
-      #can_sends.append(create_acc_cmd(self.packer, actuators.accel, enabled, raw_cnt))
+      #can_sends.append(create_acc_cmd(self.packer, actuators.accel, enabled, raw_cnt, CS.gas_override, cs_out.standstill))
 
       # SNG auto resume
       auto_resume_allowed = enabled and cs_out.cruiseState.standstill

--- a/selfdrive/car/proton/carstate.py
+++ b/selfdrive/car/proton/carstate.py
@@ -47,6 +47,7 @@ class CarState(CarStateBase):
     self.hand_on_wheel_warning_2 = False
     self.prev_angle = 0
     self.res_btn_pressed = False
+    self.gas_override = False
 
     f = Features()
     self.mads = f.has("StockAcc")
@@ -126,7 +127,8 @@ class CarState(CarStateBase):
     ret.stockFcw = bool(cp.vl["FCW"]["STOCK_FCW_TRIGGERED"])
 
     self.acc_req = cp.vl["ACC_CMD"]["ACC_REQ"]
-    ret.cruiseState.available = cruise_available = bool(cp.vl["PCM_BUTTONS"]["ACC_ON_OFF_BUTTON"] or cp.vl["PCM_BUTTONS"]["GAS_OVERRIDE"])
+    self.gas_override = gas_override = cp.vl["PCM_BUTTONS"]["GAS_OVERRIDE"]
+    ret.cruiseState.available = cruise_available = bool(gas_override or cp.vl["PCM_BUTTONS"]["ACC_ON_OFF_BUTTON"])
     ret.cruiseState.setDistance = self.parse_set_distance(self.set_distance_values.get(int(cp.vl["PCM_BUTTONS"]['SET_DISTANCE']), None))
     self.res_btn_pressed = cp.vl["ACC_BUTTONS"]["RES_BUTTON"]
 

--- a/selfdrive/car/proton/interface.py
+++ b/selfdrive/car/proton/interface.py
@@ -50,7 +50,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.0000015
 
       ret.longitudinalTuning.kpBP = [0., 5., 20.]
-      ret.longitudinalTuning.kpV = [2.0, 2.0, 2.0]
+      ret.longitudinalTuning.kpV = [5.0, 3.6, 3.6]
       ret.longitudinalActuatorDelayLowerBound = 0.42
       ret.longitudinalActuatorDelayUpperBound = 0.60
 
@@ -71,7 +71,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.0000015
 
       ret.longitudinalTuning.kpBP = [0., 5., 20.]
-      ret.longitudinalTuning.kpV = [2.0, 2.0, 2.0]
+      ret.longitudinalTuning.kpV = [5.0, 3.6, 3.6]
       ret.longitudinalActuatorDelayLowerBound = 0.42
       ret.longitudinalActuatorDelayUpperBound = 0.60
 
@@ -92,7 +92,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.0000015
 
       ret.longitudinalTuning.kpBP = [0., 5., 20.]
-      ret.longitudinalTuning.kpV = [2.0, 2.0, 2.0]
+      ret.longitudinalTuning.kpV = [5.0, 3.6, 3.6]
       ret.longitudinalActuatorDelayLowerBound = 0.42
       ret.longitudinalActuatorDelayUpperBound = 0.60
 
@@ -115,7 +115,7 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kf = 0.000006
 
       ret.longitudinalTuning.kpBP = [0., 5., 20.]
-      ret.longitudinalTuning.kpV = [2.0, 2.0, 2.0]
+      ret.longitudinalTuning.kpV = [5.0, 3.6, 3.6]
       ret.longitudinalActuatorDelayLowerBound = 0.42
       ret.longitudinalActuatorDelayUpperBound = 0.60
 
@@ -127,7 +127,7 @@ class CarInterface(CarInterfaceBase):
     ret.longitudinalTuning.deadzoneBP = [0., 8.05]
     ret.longitudinalTuning.deadzoneV = [0, 0]
     ret.longitudinalTuning.kiBP = [0., 5., 20.]
-    ret.longitudinalTuning.kiV = [0.1, 0.1, 0.1]
+    ret.longitudinalTuning.kiV = [1.5, 1.0, 1.0]
 
     ret.minEnableSpeed = -1
     ret.enableBsm = True

--- a/selfdrive/car/proton/interface.py
+++ b/selfdrive/car/proton/interface.py
@@ -141,22 +141,22 @@ class CarInterface(CarInterfaceBase):
   # returns a car.CarState
   def update(self, c, can_strings):
     # to receive CAN Messages
-    self.cp.update_strings(can_strings)
+    (cp := self.cp).update_strings(can_strings)
 
-    ret = self.CS.update(self.cp)
-    ret.canValid = self.cp.can_valid
-    ret.steeringRateLimited = self.CC.steer_rate_limited if self.CC is not None else False
+    ret = (cs := self.CS).update(cp)
+    ret.canValid = cp.can_valid
+    cc = self.CC
+    ret.steeringRateLimited = cc.steer_rate_limited if cc else False
 
     # events
     events = self.create_common_events(ret)
 
-    if (self.CS.hand_on_wheel_warning or self.CS.hand_on_wheel_warning_2) and self.CS.is_icc_on:
+    if cs.is_icc_on and (cs.hand_on_wheel_warning or cs.hand_on_wheel_warning_2):
       events.add(EventName.protonHandOnWheelWarning)
 
     ret.events = events.to_msg()
-
-    self.CS.out = ret.as_reader()
-    return self.CS.out
+    cs.out = ret.as_reader()
+    return cs.out
 
   # pass in a car.CarControl to be called at 100hz
   def apply(self, c):

--- a/selfdrive/car/proton/protoncan.py
+++ b/selfdrive/car/proton/protoncan.py
@@ -110,8 +110,11 @@ def create_pcm(packer, steer, steer_req, raw_cnt):
 
   return packer.make_can_msg("PCM_BUTTONS", 0, values)
 
-def create_acc_cmd(packer, accel, enabled, raw_cnt):
-  accel_cmd = accel * 10
+def create_acc_cmd(packer, accel, enabled, raw_cnt, gas_override, standstill):
+  # Does not work because it can keep car standstill but cannot make car move when lead car moves
+  # keep_standstill = enabled and standstill and accel < 0.21
+  keep_standstill = False
+  accel_cmd = -31 if keep_standstill else accel * 10
   values = {
     "CMD": accel_cmd,
     "CMD_OFFSET1": accel_cmd,
@@ -119,18 +122,18 @@ def create_acc_cmd(packer, accel, enabled, raw_cnt):
     "ACC_REQ": enabled,
     "NOT_ACC_REQ": not enabled,
     "SET_ME_1": 1,
-    "CRUISE_ENABLE": enabled,
+    "CRUISE_ENABLE": enabled and not gas_override,
     "COUNTER": raw_cnt,
 
     # not sure
     "BRAKE_ENGAGED": 0,
     "SET_ME_X6A": 0x6A,
-    "RISING_ENGAGE": 0,
+    "RISING_ENGAGE": gas_override,
     "UNKNOWN1": 0,
-    "STATIONARY": 0,
-    "STANDSTILL2": 0,
-    # 4 = Brake, 3 = Accelerate, 1 = Maintain speed
-    "MOTION_CONTROL": (accel > 0) * 3 + (accel < 0) * 4 + (accel == 0)
+    "STATIONARY": keep_standstill,
+    "STANDSTILL2": keep_standstill or gas_override,
+    # 5 = Keep standstill, 3 = Accelerate, 4 = Brake, 1 = Maintain speed
+    "MOTION_CONTROL": 5 if keep_standstill else 3 if accel > 0 else 4 if accel < 0 else 1
   }
 
   dat = packer.make_can_msg("ACC_CMD", 0, values)[2]

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -57,19 +57,19 @@ SafetyModel = car.CarParams.SafetyModel
 IGNORED_SAFETY_MODES = [SafetyModel.silent, SafetyModel.noOutput]
 CSID_MAP = {"0": EventName.roadCameraError, "1": EventName.wideRoadCameraError, "2": EventName.driverCameraError}
 
+def reduce_steer(steer, steeringAngle, CSAngleDeg, resume_diff):
+  end_time = 1.75 # The time where the steering becomes 100% again
+  if resume_diff >= end_time:
+    return steer, steeringAngle
+
+  # Non-linear increment equation
+  rate = 0.003    # Higher value means steeper curve. When rate is 0, the curve becomes linear.
+  mul = min(1, (resume_diff / end_time) ** (1-rate))
+  return steer * mul, (steeringAngle - CSAngleDeg) * mul + CSAngleDeg
+
 class Controls:
   def time_diff(self, frame_type):
    return (self.sm.frame - frame_type) * DT_CTRL
-
-  def reduce_steer(self, steer, steeringAngle, CSAngleDeg, resume_diff):
-    end_time = 1.75 # The time where the steering becomes 100% again
-    if resume_diff >= end_time:
-      return steer, steeringAngle
-
-    # Non-linear increment equation
-    rate = 0.003    # Higher value means steeper curve. When rate is 0, the curve becomes linear.
-    mul = min(1, (resume_diff / end_time) ** (1-rate))
-    return steer * mul, (steeringAngle - CSAngleDeg) * mul + CSAngleDeg
 
   def __init__(self, sm=None, pm=None, can_sock=None):
     config_realtime_process(4 if TICI else 3, Priority.CTRL_HIGH)
@@ -587,7 +587,7 @@ class Controls:
     # Reduce steering after resume
     if recent_steer_resume := ((resume_diff := self.time_diff(self.last_steer_resume_frame)) < 2.0):
       actuators.steer, actuators.steeringAngleDeg = \
-        self.reduce_steer(actuators.steer, actuators.steeringAngleDeg, CS.steeringAngleDeg, resume_diff)
+        reduce_steer(actuators.steer, actuators.steeringAngleDeg, CS.steeringAngleDeg, resume_diff)
 
     # Send a "steering required alert" if saturation count has reached the limit
     if lac_log.active and lac_log.saturated and not CS.steeringPressed:


### PR DESCRIPTION
In `controlsd` moving the `reduce_steer` function outside of the class since it doesn't involve anything which requires using `self`.
Optimised `update` function in Proton interface to use the walrus operator and local variables where possible.

These optimisations reduce repetitive attribute lookups, so performance is improved.

All changes were tested working well on X50.
