### PR TITLE
Proton shorten one-touch signal to match dashboard

### DIFF
--- a/selfdrive/car/proton/carstate.py
+++ b/selfdrive/car/proton/carstate.py
@@ -11,7 +11,7 @@ from selfdrive.controls.lib.desire_helper import LANE_CHANGE_SPEED_MIN
 from common.features import Features
 from common.params import Params
 
-BLINKER_MIN = 3.5 # Minimum turn signal length in seconds
+BLINKER_MIN = 2.25 # Minimum turn signal length in seconds
 
 class Dir(Enum):
   LEFT = auto()


### PR DESCRIPTION
Shorten minimum turn signal time for Proton to match dashboard display/sound, measured and tested, confirmed it's 2.25 seconds for 3 blinks (80 blinks per minute).