### PR TITLE
Update supported_vehicle.json

### DIFF
--- a/selfdrive/car/supported_vehicle.json
+++ b/selfdrive/car/supported_vehicle.json
@@ -170,8 +170,8 @@
     },
     {
       "brand": "Honda",
-      "model": "CRV",
-      "year": "2023-2025",
+      "model": "CRV Gen 5",
+      "year": "2016-2023",
       "variant": "All",
       "acc_low_speed": true,
       "acc_speed_range": "0 - 145",
@@ -311,7 +311,7 @@
     {
       "brand": "Lexus",
       "model": "ES",
-      "year": "2019-2024",
+      "year": "2019-2022",
       "variant": "All",
       "acc_low_speed": true,
       "acc_speed_range": "0 - 140",
@@ -325,7 +325,7 @@
     {
       "brand": "Lexus",
       "model": "NX",
-      "year": "2020-2024",
+      "year": "2020-2022",
       "variant": "All",
       "acc_low_speed": true,
       "acc_speed_range": "0 - 140",
@@ -339,7 +339,7 @@
     {
       "brand": "Lexus",
       "model": "UX",
-      "year": "2020-2024",
+      "year": "2020-2022",
       "variant": "All",
       "acc_low_speed": true,
       "acc_speed_range": "0 - 140",
@@ -353,7 +353,7 @@
     {
       "brand": "Lexus",
       "model": "RX",
-      "year": "2020-2024",
+      "year": "2020-2022",
       "variant": "All",
       "acc_low_speed": true,
       "acc_speed_range": "0 - 140",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Data-only changes, but they affect which vehicle years/models are advertised as supported; incorrect ranges could mislead users about compatibility.
> 
> **Overview**
> Updates `selfdrive/car/supported_vehicle.json` vehicle support metadata.
> 
> Renames the Honda entry from `CRV` to `CRV Gen 5` and changes its supported year range from `2023-2025` to `2016-2023`. Tightens supported year ranges for several Lexus models (`ES`, `NX`, `UX`, `RX`) from `*-2024` to `*-2022`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a632780aa54d0ede3ef53ae5627823c46fbec29c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->