### PR TITLE
PR release ka2: Proton make cruise available always True

### DIFF
--- a/selfdrive/car/proton/carcontroller.py
+++ b/selfdrive/car/proton/carcontroller.py
@@ -150,7 +150,7 @@ class CarController(CarControllerBase):
     if not pcm_cancel_cmd:
       self.cancel_press_cnt = 0
       self.last_cancel_press = 0
-    elif self.frame > self.last_cancel_press + 15 and not CS.out.brakePressed:
+    elif self.frame > self.last_cancel_press + 25 and not CS.out.brakePressed:
       can_sends.append(send_buttons(self.packer, 1))
       self.cancel_press_cnt += 1
       if self.cancel_press_cnt == 2:

--- a/selfdrive/car/proton/carstate.py
+++ b/selfdrive/car/proton/carstate.py
@@ -162,12 +162,9 @@ class CarState(CarStateBase):
     self.cruise_standstill = bool(cp_cam.vl["ACC_CMD"]["STANDSTILL_REQ"]) and not ret.gasPressed
     ret.cruiseState.standstill = False
     ret.cruiseState.nonAdaptive = False
-    if self.CP.carFingerprint == CAR.X50:
-      ret.cruiseState.enabled = cp_cam.vl["ACC_CMD"]['CRUISE_DISABLED'] != 1
-    else:
-      ret.cruiseState.enabled = (cp_cam.vl["ACC_CMD"]["ACC_REQ"] \
-                                + cp_cam.vl["ACC_CMD"]["STANDSTILL_REQ"] \
-                                + cp_cam.vl["ACC_CMD"]["NOT_GAS_OVERRIDE"]) > 1
+    ret.cruiseState.enabled = (cp_cam.vl["ACC_CMD"]["ACC_REQ"] \
+                           + cp_cam.vl["ACC_CMD"]["STANDSTILL_REQ"] \
+                           + cp_cam.vl["ACC_CMD"]["NOT_GAS_OVERRIDE"]) > 1
 
     # button presses
     ret.leftBlinker = bool(cp.vl["LEFT_STALK"]["LEFT_SIGNAL"])

--- a/selfdrive/car/proton/carstate.py
+++ b/selfdrive/car/proton/carstate.py
@@ -147,10 +147,8 @@ class CarState(CarStateBase):
     ret.stockAeb = False
     ret.stockFcw = bool(cp_cam.vl["FCW"]["STOCK_FCW_TRIGGERED"])
 
-    if self.CP.carFingerprint == CAR.X50:
-      ret.cruiseState.available = bool(cp_cam.vl["PCM_BUTTONS"]['CRUISE_AVAILABLE'])
-    else: #TODO
-      ret.cruiseState.available = True
+    #TODO: If using car signal, S70 cannot engage, X50 gas press would make it False.
+    ret.cruiseState.available = True
 
     self.res_btn_pressed = bool(cp.vl["ACC_BUTTONS"]["RES_BUTTON"])
     distance_val = int(cp_cam.vl["PCM_BUTTONS"]['SET_DISTANCE'])


### PR DESCRIPTION
[9a7a7cb](https://github.com/kommuai/bukapilot/commit/9a7a7cbb095687947ba330ee3939de8215d27885) increases interval between cancel presses, so on S70 it won't sometimes turn off cruise because of a second press.